### PR TITLE
Cleanup assets backup after rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -395,9 +395,17 @@ jobs:
           aws s3 sync "s3://$R2_BUCKET_NAME/${BACKUP_PREFIX}/images" "s3://$R2_BUCKET_NAME/images" --endpoint-url "$R2_S3_ENDPOINT" --delete --acl public-read
 
           echo "✅ Assets restored from backup: $BACKUP_PREFIX"
+
+          # Clean up backup after rollback
+          echo "Cleaning up backup after rollback..."
+          aws s3 rm "s3://$R2_BUCKET_NAME/${BACKUP_PREFIX}" --endpoint-url "$R2_S3_ENDPOINT" --recursive --quiet
+          echo "✅ Backup cleaned up after rollback: $BACKUP_PREFIX"
         else
           echo "⚠️ Backup not found: $BACKUP_PREFIX"
         fi
+
+        # Remove local backup ID file
+        rm -f deploy/.asset_backup_id
 
     - name: Rollback on failure
       if: failure()


### PR DESCRIPTION
This pull request introduces cleanup steps to the deployment workflow to ensure backups and temporary files are properly removed after a rollback. The most important changes include adding commands to delete the backup from S3 and removing a local backup ID file.

### Deployment workflow improvements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R398-R409): Added a step to clean up the backup from S3 after a rollback using `aws s3 rm` with the `--recursive` and `--quiet` options.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R398-R409): Added a command to remove the local backup ID file (`deploy/.asset_backup_id`) after a rollback.