### PR TITLE
Emails by Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,9 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
+# Resend Configuration
+RESEND_API_KEY=re_xxxxxxxxx
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project utilizes a variety of modern technologies for both the backend and 
 - **Frontend:** React.js
 - **Interactivity:** Inertia.js to seamlessly connect the backend and frontend.
 - **UI Components:** shadcn/ui for beautifully designed UI components.
+- **Email Service:** Resend for reliable email delivery
 
 ## Installation Instructions
 

--- a/app/Console/Commands/TestResendEmail.php
+++ b/app/Console/Commands/TestResendEmail.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\ContactFormMail;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+use Resend\Laravel\Facades\Resend;
+
+class TestResendEmail extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'resend:test {email} {--method=mail : Method to use (mail or resend)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Test Resend email integration by sending a test email';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $email = $this->argument('email');
+        $method = $this->option('method');
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $this->error('Please provide a valid email address.');
+            return 1;
+        }
+
+        $this->info("Testing Resend integration...");
+        $this->info("Sending to: {$email}");
+        $this->info("Method: {$method}");
+
+        try {
+            if ($method === 'resend') {
+                $this->sendWithResendFacade($email);
+            } else {
+                $this->sendWithMailFacade($email);
+            }
+
+            $this->info('✅ Email sent successfully!');
+            return 0;
+        } catch (\Exception $e) {
+            $this->error('❌ Failed to send email: ' . $e->getMessage());
+            return 1;
+        }
+    }
+
+    private function sendWithMailFacade($email)
+    {
+        $data = [
+            'name' => 'Test User',
+            'email' => $email,
+            'subject' => 'Test Email via Mail Facade',
+            'message' => 'This is a test email sent via Laravel Mail facade using Resend.',
+            'services' => ['Testing'],
+            'referrer' => 'artisan-command'
+        ];
+
+        Mail::to($email)->send(new ContactFormMail($data));
+        $this->line('Sent using Laravel Mail facade');
+    }
+
+    private function sendWithResendFacade($email)
+    {
+        $result = Resend::emails()->send([
+            'from' => config('mail.from.address'),
+            'to' => [$email],
+            'subject' => 'Test Email via Resend Facade',
+            'html' => '
+                <h1>🚀 Resend Test Email</h1>
+                <p>This is a test email sent directly via the Resend facade.</p>
+                <p><strong>Sent from:</strong> ' . config('app.name') . '</p>
+                <p><strong>Timestamp:</strong> ' . now()->toDateTimeString() . '</p>
+                <hr>
+                <p><em>This email was sent using the Resend Laravel package.</em></p>
+            ',
+        ]);
+
+        $this->line('Sent using Resend facade');
+        $this->line('Resend Email ID: ' . ($result['id'] ?? 'N/A'));
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,7 +16,10 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        // Exclude Resend webhook from CSRF protection
+        $middleware->validateCsrfTokens(except: [
+            'resend/*',
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "laravel/framework": "^11.31",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",
+        "resend/resend-laravel": "^0.19.0",
         "tightenco/ziggy": "^2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f8fad98d414b6e76b3cad63a981e25e",
+    "content-hash": "e894166115ced0addff1a64a2dc2ba2b",
     "packages": [
         {
             "name": "brick/math",
@@ -3417,6 +3417,132 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "resend/resend-laravel",
+            "version": "v0.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/resend/resend-laravel.git",
+                "reference": "ce11e363c42c1d6b93983dfebbaba3f906863c3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/resend/resend-laravel/zipball/ce11e363c42c1d6b93983dfebbaba3f906863c3a",
+                "reference": "ce11e363c42c1d6b93983dfebbaba3f906863c3a",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": "^8.1",
+                "resend/resend-php": "^0.18.0",
+                "symfony/mailer": "^6.2|^7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^8.17|^9.0|^10.0",
+                "pestphp/pest": "^2.0|^3.7"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Resend\\Laravel\\ResendServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Resend\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Resend and contributors",
+                    "homepage": "https://github.com/resend/resend-laravel/contributors"
+                }
+            ],
+            "description": "Resend for Laravel",
+            "homepage": "https://resend.com/",
+            "keywords": [
+                "api",
+                "client",
+                "laravel",
+                "php",
+                "resend",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/resend/resend-laravel/issues",
+                "source": "https://github.com/resend/resend-laravel/tree/v0.19.0"
+            },
+            "time": "2025-05-06T21:36:51+00:00"
+        },
+        {
+            "name": "resend/resend-php",
+            "version": "v0.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/resend/resend-php.git",
+                "reference": "d6194782ff1952627bcdd52e5958572c4bd98043"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/resend/resend-php/zipball/d6194782ff1952627bcdd52e5958572c4bd98043",
+                "reference": "d6194782ff1952627bcdd52e5958572c4bd98043",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.5",
+                "php": "^8.1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.13",
+                "mockery/mockery": "^1.6",
+                "pestphp/pest": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resend.php"
+                ],
+                "psr-4": {
+                    "Resend\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Resend and contributors",
+                    "homepage": "https://github.com/resend/resend-php/contributors"
+                }
+            ],
+            "description": "Resend PHP library.",
+            "homepage": "https://resend.com/",
+            "keywords": [
+                "api",
+                "client",
+                "php",
+                "resend",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/resend/resend-php/issues",
+                "source": "https://github.com/resend/resend-php/tree/v0.18.0"
+            },
+            "time": "2025-05-06T21:18:26+00:00"
         },
         {
             "name": "symfony/clock",
@@ -8337,12 +8463,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/docs/RESEND_SETUP.md
+++ b/docs/RESEND_SETUP.md
@@ -1,0 +1,187 @@
+# Resend Email Integration
+
+This project uses [Resend](https://resend.com) for sending emails through Laravel. Resend provides a modern, developer-friendly email API with excellent deliverability.
+
+## Setup
+
+### 1. Environment Configuration
+
+The Resend package has been installed and configured. You need to set up your environment variables:
+
+```env
+# Set the mail driver to use Resend
+MAIL_MAILER=resend
+
+# Your Resend API key (get this from https://resend.com/api-keys)
+RESEND_API_KEY=re_xxxxxxxxx
+
+# Optional: Webhook secret for verifying webhook signatures
+RESEND_WEBHOOK_SECRET=your_webhook_secret_here
+
+# Configure your from address (must be from a verified domain)
+MAIL_FROM_ADDRESS="hello@yourdomain.com"
+MAIL_FROM_NAME="Your App Name"
+```
+
+### 2. Domain Verification
+
+Before sending emails, you need to verify your domain in the Resend dashboard:
+
+1. Go to [Resend Dashboard](https://resend.com/domains)
+2. Add your domain
+3. Configure the required DNS records
+4. Wait for verification
+
+### 3. API Key Setup
+
+1. Go to [Resend API Keys](https://resend.com/api-keys)
+2. Create a new API key
+3. Copy the key and add it to your `.env` file as `RESEND_API_KEY`
+
+## Usage
+
+### Method 1: Using Laravel's Mail Facade (Recommended)
+
+This is the standard Laravel way and works with all existing Mailable classes:
+
+```php
+use Illuminate\Support\Facades\Mail;
+use App\Mail\ContactFormMail;
+
+// Send using existing Mailable class
+Mail::to('recipient@example.com')->send(new ContactFormMail($data));
+```
+
+### Method 2: Using Resend Facade Directly
+
+For more control or when you need Resend-specific features:
+
+```php
+use Resend\Laravel\Facades\Resend;
+
+$result = Resend::emails()->send([
+    'from' => 'sender@yourdomain.com',
+    'to' => ['recipient@example.com'],
+    'subject' => 'Hello from Resend',
+    'html' => '<h1>Hello World!</h1>',
+]);
+
+// The result contains the email ID from Resend
+$emailId = $result['id'];
+```
+
+## Testing the Integration
+
+You can test the Resend integration using the existing contact form or the Artisan command:
+
+### Using the Contact Form
+
+1. Navigate to `/contact` on your website
+2. Fill out and submit the contact form
+3. The email will be sent via Resend using the existing `ContactFormMail` class
+
+### Using the Artisan Command
+
+```bash
+# Test with Mail facade (recommended)
+php artisan resend:test your-email@example.com
+
+# Test with Resend facade directly
+php artisan resend:test your-email@example.com --method=resend
+```
+
+## Webhooks
+
+Resend can send webhooks for email events (delivered, bounced, etc.). The webhook endpoint is automatically configured at `/resend/webhook`.
+
+### Setting up Webhooks
+
+1. Go to [Resend Webhooks](https://resend.com/webhooks)
+2. Add your webhook URL: `https://yourdomain.com/resend/webhook`
+3. Select the events you want to receive
+4. Copy the signing secret and add it to your `.env` as `RESEND_WEBHOOK_SECRET`
+
+### Webhook Events
+
+The package automatically dispatches Laravel events for Resend webhooks:
+
+- `email.sent` → `EmailSent` event
+- `email.delivered` → `EmailDelivered` event
+- `email.bounced` → `EmailBounced` event
+- `email.complained` → `EmailComplained` event
+
+You can listen to these events in your `EventServiceProvider`:
+
+```php
+protected $listen = [
+    \Resend\Laravel\Events\EmailDelivered::class => [
+        \App\Listeners\HandleEmailDelivered::class,
+    ],
+];
+```
+
+## Configuration Files
+
+### Mail Configuration
+
+The Resend mailer is configured in `config/mail.php`:
+
+```php
+'mailers' => [
+    'resend' => [
+        'transport' => 'resend',
+    ],
+    // ... other mailers
+],
+```
+
+### CSRF Protection
+
+Webhook routes are excluded from CSRF protection in `bootstrap/app.php`:
+
+```php
+$middleware->validateCsrfTokens(except: [
+    'resend/*',
+]);
+```
+
+## Existing Email Classes
+
+The project already includes:
+
+- `App\Mail\ContactFormMail` - For contact form submissions
+- Email template: `resources/views/emails/contact-form.blade.php`
+
+These will automatically work with Resend once you update your environment variables.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Error**: Check your `RESEND_API_KEY` is correct
+2. **Domain Not Verified**: Ensure your sending domain is verified in Resend
+3. **Rate Limits**: Resend has rate limits based on your plan
+4. **Webhook Verification Failed**: Check your `RESEND_WEBHOOK_SECRET`
+
+### Logs
+
+Check Laravel logs for detailed error messages:
+
+```bash
+tail -f storage/logs/laravel.log
+```
+
+### Testing in Development
+
+For local development, you can use tools like [ngrok](https://ngrok.com) to expose your local server for webhook testing:
+
+```bash
+ngrok http 8000
+# Use the HTTPS URL for webhook configuration
+```
+
+## Resources
+
+- [Resend Documentation](https://resend.com/docs)
+- [Resend Laravel Package](https://github.com/resendlabs/resend-laravel)
+- [Laravel Mail Documentation](https://laravel.com/docs/mail) 


### PR DESCRIPTION
This pull request introduces the integration of the Resend email service into the project. It includes the necessary setup, configuration, and documentation to enable email delivery using Resend, along with a new Artisan command for testing the integration.

### Resend Email Integration:

* **Environment Configuration**:
  - Added `RESEND_API_KEY` to `.env.example` for Resend API key configuration. (`.env.example`, [.env.exampleR60-R62](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR60-R62))
  - Updated `composer.json` to include the `resend/resend-laravel` package. (`composer.json`, [composer.jsonR17](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R17))

* **New Command for Testing**:
  - Introduced `TestResendEmail` Artisan command to test email delivery using either the Laravel Mail facade or the Resend facade. (`app/Console/Commands/TestResendEmail.php`, [app/Console/Commands/TestResendEmail.phpR1-R92](diffhunk://#diff-2736be32f1200900330256b50077d34cb1ec88f0f369c88f25c2e295f4375ca2R1-R92))

* **Documentation**:
  - Added a comprehensive guide in `docs/RESEND_SETUP.md` detailing how to configure and use Resend for email delivery, including setup, usage, and troubleshooting. (`docs/RESEND_SETUP.md`, [docs/RESEND_SETUP.mdR1-R187](diffhunk://#diff-04fa3a1b7248b10fe5c81bd8ebe5ca3279fdb08fe57cced77494d8e5a71e509cR1-R187))
  - Updated `README.md` to include Resend as the email service used in the project. (`README.md`, [README.mdR15](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15))

* **Middleware Adjustment**:
  - Excluded Resend webhook routes (`resend/*`) from CSRF protection in the middleware configuration. (`bootstrap/app.php`, [bootstrap/app.phpL19-R22](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518L19-R22))