### PR TITLE
fix: upgrade portfolio runtime to php 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "inertiajs/inertia-laravel": "^3.1.0",
         "laravel/framework": "^13.11.2",
         "laravel/sanctum": "^4.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -8820,7 +8820,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "^8.4"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM php:8.3-fpm-alpine AS builder
+FROM php:8.4-fpm-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache $PHPIZE_DEPS postgresql-dev libzip-dev zip unzip git \
@@ -23,7 +23,7 @@ RUN wget https://getcomposer.org/composer-stable.phar -O composer.phar \
     && rm composer.phar
 
 # Production image
-FROM php:8.3-fpm-alpine AS php-fpm
+FROM php:8.4-fpm-alpine AS php-fpm
 
 # Install runtime and build dependencies only
 RUN apk add --no-cache postgresql-libs postgresql-dev libzip openssl \


### PR DESCRIPTION
## Summary\n- Upgrade the portfolio backend runtime from PHP 8.3 to PHP 8.4\n- Align Composer platform requirements with the new runtime floor\n- Update the Docker build and runtime images to PHP 8.4\n\n## Why\nThe deploy build was failing because locked Symfony packages require PHP >=8.4.\n\n## Test plan\n- [x] Commit created on feature branch\n- [x] Pushed branch to origin\n- [ ] CI / deploy workflow verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded PHP version requirement from 8.3 to 8.4
  * Updated Docker images to use PHP 8.4 in development and production environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HarunRRayhan/portfolio/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->