### PR TITLE
Show view counts on blog listing cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ deploy/.env.**
 !deploy/.env.example
 !deploy/.env.*.example
 **/__pycache__/
+
+# Claude Code plan-mode scratch files — not app code, never deployed
+/reports/

--- a/resources/js/Pages/Blog/Index.tsx
+++ b/resources/js/Pages/Blog/Index.tsx
@@ -1,5 +1,5 @@
 import { Head, Link } from '@inertiajs/react'
-import { ArrowRight, CalendarDays, Clock3, MessageCircle, Rss, Sparkles, Tag } from 'lucide-react'
+import { ArrowRight, CalendarDays, Clock3, Eye, MessageCircle, Rss, Sparkles, Tag } from 'lucide-react'
 
 interface BlogPostSummary {
   title: string
@@ -12,6 +12,7 @@ interface BlogPostSummary {
   responseCount: number
   replyCount: number
   coverImageUrl?: string | null
+  viewCount: number
   tags: Array<{ name: string; slug: string }>
   url: string
   canonicalUrl: string
@@ -151,6 +152,10 @@ export default function BlogIndex({ posts, canonicalUrl }: BlogIndexProps) {
                         <span className="inline-flex items-center gap-1.5">
                           <MessageCircle className="h-3.5 w-3.5" />
                           {post.responseCount + post.replyCount} comments
+                        </span>
+                        <span className="inline-flex items-center gap-1.5">
+                          <Eye className="h-3.5 w-3.5" />
+                          {post.viewCount ?? 0} views
                         </span>
                       </div>
 


### PR DESCRIPTION
## Summary
- Surface the already-live `viewCount` field on the blog listing page (`/blog`), mirroring the detail page which already shows it.
- Add `/reports/` to `.gitignore` — these are Claude Code plan-mode scratch files, not app code, and shouldn't show as untracked noise.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Verified locally at `http://127.0.0.1:8000/blog`: each card renders an "N views" line with the Eye icon, next to date/read-time/comments
- [x] Backend already live (no changes needed): `blog_post_views` table, view recording in `routes/web.php`, `BlogRepository::summarizePost()`

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE