### PR TITLE
Add self-hosted URL shortener with click analytics

### DIFF
--- a/app/Http/Controllers/Admin/ShortLinkController.php
+++ b/app/Http/Controllers/Admin/ShortLinkController.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ShortLink;
+use App\Models\ShortLinkClick;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ShortLinkController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('Admin/Short/Index', [
+            'links' => ShortLink::query()
+                ->withCount('clicks')
+                ->orderByDesc('id')
+                ->get()
+                ->map(fn (ShortLink $link) => $this->toPayload($link))
+                ->all(),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return Inertia::render('Admin/Short/Create');
+    }
+
+    /**
+     * Click analytics over a trailing window (default 30 days). Pass ?link=
+     * to scope every figure to a single short link instead of all of them.
+     */
+    public function analytics(Request $request): Response
+    {
+        $days = (int) $request->integer('days', 30);
+        $days = in_array($days, [7, 30, 90], true) ? $days : 30;
+
+        $linkId = $request->integer('link') ?: null;
+        $selectedLink = $linkId ? ShortLink::find($linkId) : null;
+
+        $since = now()->subDays($days - 1)->startOfDay();
+
+        $scoped = fn (Builder $query) => $linkId ? $query->where('short_link_id', $linkId) : $query;
+
+        $clicks = $scoped(ShortLinkClick::query())->where('created_at', '>=', $since);
+
+        return Inertia::render('Admin/Short/Analytics', [
+            'days' => $days,
+            'links' => ShortLink::query()->orderByDesc('id')->get(['id', 'code', 'title'])
+                ->map(fn (ShortLink $l) => ['id' => $l->id, 'code' => $l->code, 'title' => $l->title])
+                ->all(),
+            'selectedLinkId' => $linkId,
+            'totalClicks' => $scoped(ShortLinkClick::query())->count(),
+            'windowClicks' => (clone $clicks)->count(),
+            'daily' => $this->dailySeries($since, $days, $linkId),
+            'byLink' => $linkId ? [] : $this->clicksByLink($since),
+            'byCountry' => $this->groupCounts((clone $clicks), 'country'),
+            'byReferer' => $this->refererCounts((clone $clicks)),
+        ]);
+    }
+
+    /**
+     * One row per day in the window, including days with no clicks -- a bar
+     * chart with gaps silently rescales the x axis and misreads as continuous.
+     *
+     * @return list<array{date: string, clicks: int}>
+     */
+    private function dailySeries(\DateTimeInterface $since, int $days, ?int $linkId): array
+    {
+        $query = ShortLinkClick::query()->where('created_at', '>=', $since);
+
+        if ($linkId) {
+            $query->where('short_link_id', $linkId);
+        }
+
+        $counts = $query
+            ->selectRaw('date(created_at) as day, count(*) as clicks')
+            ->groupBy('day')
+            ->pluck('clicks', 'day');
+
+        return collect(range(0, $days - 1))
+            ->map(function (int $offset) use ($since, $counts) {
+                $date = Carbon::parse($since)->addDays($offset)->toDateString();
+
+                return [
+                    'date' => $date,
+                    'clicks' => (int) ($counts[$date] ?? 0),
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @return list<array{id: int, code: string, title: ?string, clicks: int}>
+     */
+    private function clicksByLink(\DateTimeInterface $since): array
+    {
+        return ShortLink::query()
+            ->withCount(['clicks as clicks' => fn ($q) => $q->where('created_at', '>=', $since)])
+            ->orderByDesc('clicks')
+            ->get()
+            ->map(fn (ShortLink $link) => [
+                'id' => $link->id,
+                'code' => $link->code,
+                'title' => $link->title,
+                'clicks' => (int) $link->clicks,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return list<array{key: string, clicks: int}>
+     */
+    private function groupCounts(Builder $query, string $column): array
+    {
+        return $query
+            ->whereNotNull($column)
+            ->selectRaw("{$column} as key, count(*) as clicks")
+            ->groupBy($column)
+            ->orderByDesc('clicks')
+            ->limit(10)
+            ->get()
+            ->map(fn ($row) => ['key' => (string) $row->key, 'clicks' => (int) $row->clicks])
+            ->all();
+    }
+
+    /**
+     * Referers are grouped by host: the full URL fragments the counts into
+     * near-duplicates that say nothing about where traffic came from.
+     *
+     * @return list<array{key: string, clicks: int}>
+     */
+    private function refererCounts(Builder $query): array
+    {
+        return $query
+            ->whereNotNull('referer')
+            ->pluck('referer')
+            ->map(fn (?string $url) => $url ? (parse_url($url, PHP_URL_HOST) ?: null) : null)
+            ->filter()
+            ->countBy()
+            ->sortDesc()
+            ->take(10)
+            ->map(fn (int $clicks, string $host) => ['key' => $host, 'clicks' => $clicks])
+            ->values()
+            ->all();
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $this->validateData($request);
+
+        ShortLink::create($data);
+
+        return redirect()->route('admin.short.index')->with('flash', [
+            'type' => 'success',
+            'message' => 'Short link created.',
+        ]);
+    }
+
+    public function edit(ShortLink $shortLink): Response
+    {
+        return Inertia::render('Admin/Short/Edit', [
+            'link' => $this->toPayload($shortLink),
+        ]);
+    }
+
+    public function update(Request $request, ShortLink $shortLink): RedirectResponse
+    {
+        $data = $this->validateData($request, $shortLink);
+
+        $shortLink->update($data);
+
+        return redirect()->route('admin.short.index')->with('flash', [
+            'type' => 'success',
+            'message' => 'Short link updated.',
+        ]);
+    }
+
+    public function destroy(ShortLink $shortLink): RedirectResponse
+    {
+        $shortLink->delete();
+
+        return redirect()->route('admin.short.index')->with('flash', [
+            'type' => 'success',
+            'message' => 'Short link deleted.',
+        ]);
+    }
+
+    /**
+     * Toggle the active state of a single link (used by the index toggle switch).
+     */
+    public function toggle(ShortLink $shortLink): RedirectResponse
+    {
+        $shortLink->update(['is_active' => ! $shortLink->is_active]);
+
+        return redirect()->back();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateData(Request $request, ?ShortLink $shortLink = null): array
+    {
+        return $request->validate([
+            'destination_url' => ['required', 'url', 'max:2048'],
+            // A code can be left blank on create (one is generated), but once a
+            // link exists its code can't be cleared out from under it.
+            'code' => [
+                $shortLink ? 'required' : 'nullable',
+                'string',
+                'alpha_dash',
+                'max:60',
+                Rule::unique('short_links', 'code')->ignore($shortLink?->id),
+            ],
+            'title' => ['nullable', 'string', 'max:255'],
+            'expires_at' => ['nullable', 'date'],
+            'is_active' => ['boolean'],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toPayload(ShortLink $link): array
+    {
+        return [
+            'id' => $link->id,
+            'code' => $link->code,
+            'destination_url' => $link->destination_url,
+            'title' => $link->title,
+            'short_url' => $link->short_url,
+            'is_active' => (bool) $link->is_active,
+            'expires_at' => $link->expires_at?->format('Y-m-d\TH:i'),
+            'clicks_count' => (int) ($link->clicks_count ?? 0),
+            'created_at' => $link->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/ShortLink.php
+++ b/app/Models/ShortLink.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+class ShortLink extends Model
+{
+    protected $fillable = [
+        'code',
+        'destination_url',
+        'title',
+        'is_active',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'expires_at' => 'datetime',
+    ];
+
+    protected $appends = ['short_url'];
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $link) {
+            if (! $link->code) {
+                $link->code = static::generateUniqueCode();
+            }
+        });
+    }
+
+    /**
+     * A random base62 code, retried on the rare collision. 7 characters over a
+     * 62-symbol alphabet is billions of combinations -- collisions are a
+     * correctness concern, not a performance one, so a plain uniqueness check
+     * per attempt is enough.
+     */
+    public static function generateUniqueCode(int $length = 7): string
+    {
+        do {
+            $code = Str::random($length);
+        } while (static::where('code', $code)->exists());
+
+        return $code;
+    }
+
+    public function getShortUrlAttribute(): string
+    {
+        return url('/s/'.$this->code);
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true)
+            ->where(function ($q) {
+                $q->whereNull('expires_at')
+                  ->orWhere('expires_at', '>', now());
+            });
+    }
+
+    public function clicks(): HasMany
+    {
+        return $this->hasMany(ShortLinkClick::class);
+    }
+}

--- a/app/Models/ShortLinkClick.php
+++ b/app/Models/ShortLinkClick.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ShortLinkClick extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'short_link_id',
+        'ip_address',
+        'country',
+        'user_agent',
+        'referer',
+    ];
+
+    public function shortLink(): BelongsTo
+    {
+        return $this->belongsTo(ShortLink::class);
+    }
+}

--- a/database/migrations/2026_07_22_073338_create_short_links_table.php
+++ b/database/migrations/2026_07_22_073338_create_short_links_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('short_links', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 60)->unique();
+            $table->text('destination_url');
+            $table->string('title')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('short_links');
+    }
+};

--- a/database/migrations/2026_07_22_073339_create_short_link_clicks_table.php
+++ b/database/migrations/2026_07_22_073339_create_short_link_clicks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('short_link_clicks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('short_link_id')->constrained()->cascadeOnDelete();
+            $table->string('ip_address', 45)->nullable();
+            $table->string('country', 2)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->string('referer')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('short_link_clicks');
+    }
+};

--- a/resources/js/Pages/Admin/Short/Analytics.tsx
+++ b/resources/js/Pages/Admin/Short/Analytics.tsx
@@ -1,0 +1,312 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout'
+import { Head, Link, router } from '@inertiajs/react'
+import { useMemo, useState } from 'react'
+import { countryFlag, countryName } from '@/lib/countries'
+
+// Single measure throughout, so one hue rather than a categorical ramp.
+const SERIES = '#2a78d6'
+
+interface DailyPoint {
+  date: string
+  clicks: number
+}
+
+interface LinkOption {
+  id: number
+  code: string
+  title: string | null
+}
+
+interface LinkRow {
+  id: number
+  code: string
+  title: string | null
+  clicks: number
+}
+
+interface GroupRow {
+  key: string
+  clicks: number
+}
+
+interface Props {
+  days: number
+  links: LinkOption[]
+  selectedLinkId: number | null
+  totalClicks: number
+  windowClicks: number
+  daily: DailyPoint[]
+  byLink: LinkRow[]
+  byCountry: GroupRow[]
+  byReferer: GroupRow[]
+}
+
+const RANGES = [7, 30, 90]
+
+function linkLabel(link: { code: string; title: string | null }) {
+  return link.title ? `${link.title} (${link.code})` : link.code
+}
+
+function StatTile({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="mt-1 text-3xl font-semibold tabular-nums tracking-tight text-gray-900">{value}</p>
+      {hint && <p className="mt-1 text-xs text-gray-400">{hint}</p>}
+    </div>
+  )
+}
+
+/** Horizontal ranked list. The bar is a magnitude cue; the number is the value. */
+function RankedList({
+  title,
+  rows,
+  empty,
+  renderLabel,
+}: {
+  title: string
+  rows: GroupRow[]
+  empty: string
+  renderLabel: (key: string) => React.ReactNode
+}) {
+  const max = Math.max(1, ...rows.map((r) => r.clicks))
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+      <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+
+      {rows.length === 0 ? (
+        <p className="mt-4 text-sm text-gray-400">{empty}</p>
+      ) : (
+        <ol className="mt-4 space-y-2.5">
+          {rows.map((row) => (
+            <li key={row.key} className="grid grid-cols-[1fr_auto] items-center gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm text-gray-700">{renderLabel(row.key)}</div>
+                <div className="mt-1 h-1.5 rounded-full bg-gray-100">
+                  <div
+                    className="h-1.5 rounded-full"
+                    style={{ width: `${(row.clicks / max) * 100}%`, backgroundColor: SERIES }}
+                  />
+                </div>
+              </div>
+              <span className="text-sm font-medium tabular-nums text-gray-900">{row.clicks}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  )
+}
+
+export default function Analytics({
+  days,
+  links,
+  selectedLinkId,
+  totalClicks,
+  windowClicks,
+  daily,
+  byLink,
+  byCountry,
+  byReferer,
+}: Props) {
+  const [hover, setHover] = useState<DailyPoint | null>(null)
+
+  const max = useMemo(() => Math.max(1, ...daily.map((d) => d.clicks)), [daily])
+  const topLink = byLink.find((l) => l.clicks > 0)
+  const selectedLink = links.find((l) => l.id === selectedLinkId) ?? null
+
+  const goTo = (params: { days?: number; link?: number | null }) => {
+    router.get(
+      '/admin/short/analytics',
+      {
+        days: params.days ?? days,
+        link: 'link' in params ? params.link || undefined : selectedLinkId || undefined,
+      },
+      { preserveState: true, preserveScroll: true },
+    )
+  }
+
+  const formatDay = (iso: string) =>
+    new Date(`${iso}T00:00:00`).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+
+  return (
+    <AuthenticatedLayout
+      header={
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold leading-tight text-gray-800">Short Link Analytics</h2>
+          <Link href="/admin/short" className="text-sm text-gray-600 hover:text-gray-900">
+            Back to links
+          </Link>
+        </div>
+      }
+    >
+      <Head title="Short Link Analytics" />
+
+      <div className="py-6 sm:py-12">
+        <div className="mx-auto max-w-6xl space-y-6 px-4 sm:px-6 lg:px-8">
+          {/* Filters sit in one row above the charts. */}
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-1" role="group" aria-label="Time range">
+              {RANGES.map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => goTo({ days: r })}
+                  aria-pressed={days === r}
+                  className={
+                    'rounded-md px-3 py-1.5 text-sm font-medium transition ' +
+                    (days === r
+                      ? 'bg-gray-900 text-white'
+                      : 'bg-white text-gray-600 ring-1 ring-gray-200 hover:bg-gray-50')
+                  }
+                >
+                  {r} days
+                </button>
+              ))}
+            </div>
+
+            <select
+              value={selectedLinkId ?? ''}
+              onChange={(e) => goTo({ link: e.target.value ? Number(e.target.value) : null })}
+              className="rounded-md border-gray-300 text-sm text-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            >
+              <option value="">All links</option>
+              {links.map((link) => (
+                <option key={link.id} value={link.id}>
+                  {linkLabel(link)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <StatTile label={`Clicks in ${days} days`} value={windowClicks.toLocaleString()} />
+            <StatTile label="Clicks all time" value={totalClicks.toLocaleString()} />
+            {selectedLink ? (
+              <StatTile label="Showing" value={selectedLink.code} hint={selectedLink.title ?? undefined} />
+            ) : (
+              <StatTile
+                label="Top link"
+                value={topLink ? topLink.code : 'None yet'}
+                hint={topLink ? `${topLink.clicks.toLocaleString()} clicks` : 'No clicks yet'}
+              />
+            )}
+          </div>
+
+          {/* Clicks per day. Every day in the window is present, including zeros. */}
+          <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+            <div className="flex items-baseline justify-between">
+              <h3 className="text-sm font-semibold text-gray-900">Clicks per day</h3>
+              <p className="text-xs tabular-nums text-gray-500">
+                {hover ? `${formatDay(hover.date)} · ${hover.clicks} clicks` : `Peak ${max}`}
+              </p>
+            </div>
+
+            {windowClicks === 0 ? (
+              <p className="mt-6 text-sm text-gray-400">
+                No clicks recorded in this window yet. Clicks are tracked when someone follows a short link.
+              </p>
+            ) : (
+              <>
+                <div className="mt-4 flex h-40 items-end gap-[2px]" onMouseLeave={() => setHover(null)}>
+                  {daily.map((d) => (
+                    <button
+                      key={d.date}
+                      type="button"
+                      onMouseEnter={() => setHover(d)}
+                      onFocus={() => setHover(d)}
+                      title={`${formatDay(d.date)}: ${d.clicks} clicks`}
+                      aria-label={`${formatDay(d.date)}: ${d.clicks} clicks`}
+                      className="group relative flex h-full flex-1 items-end"
+                    >
+                      <span
+                        className="w-full rounded-t transition-opacity group-hover:opacity-80"
+                        style={{
+                          // A zero day keeps a hairline so the gap reads as
+                          // "measured zero" rather than "no data".
+                          height: d.clicks === 0 ? '2px' : `${Math.max(4, (d.clicks / max) * 100)}%`,
+                          backgroundColor: d.clicks === 0 ? '#e5e7eb' : SERIES,
+                        }}
+                      />
+                    </button>
+                  ))}
+                </div>
+
+                <div className="mt-2 flex justify-between text-xs text-gray-400">
+                  <span>{formatDay(daily[0].date)}</span>
+                  <span>{formatDay(daily[daily.length - 1].date)}</span>
+                </div>
+              </>
+            )}
+          </section>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <RankedList
+              title="Top countries"
+              rows={byCountry}
+              empty="No country data yet. Countries resolve once the GeoLite2 database is installed."
+              renderLabel={(code) => (
+                <span className="inline-flex items-center gap-2">
+                  <span aria-hidden="true">{countryFlag(code)}</span>
+                  {countryName(code)}
+                </span>
+              )}
+            />
+
+            <RankedList
+              title="Top referrers"
+              rows={byReferer}
+              empty="No referrer data yet."
+              renderLabel={(host) => host}
+            />
+          </div>
+
+          {/* Table view: the same data as the chart, readable without color. Hidden
+              when scoped to one link since it would just repeat the stat tiles above. */}
+          {!selectedLink && (
+            <section className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+              <h3 className="border-b border-gray-200 px-5 py-4 text-sm font-semibold text-gray-900">
+                Clicks by link
+              </h3>
+
+              {byLink.length === 0 ? (
+                <p className="px-5 py-6 text-sm text-gray-400">No short links yet.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+                    <tr>
+                      <th scope="col" className="px-5 py-2 font-medium">
+                        Link
+                      </th>
+                      <th scope="col" className="px-5 py-2 text-right font-medium">
+                        Clicks
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {byLink.map((link) => (
+                      <tr key={link.id}>
+                        <td className="px-5 py-3">
+                          <Link
+                            href={`/admin/short/${link.id}/edit`}
+                            className="text-gray-700 hover:text-gray-900"
+                          >
+                            {linkLabel(link)}
+                          </Link>
+                        </td>
+                        <td className="px-5 py-3 text-right font-medium tabular-nums text-gray-900">
+                          {link.clicks.toLocaleString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </section>
+          )}
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  )
+}

--- a/resources/js/Pages/Admin/Short/Create.tsx
+++ b/resources/js/Pages/Admin/Short/Create.tsx
@@ -1,0 +1,41 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout'
+import { Head, useForm } from '@inertiajs/react'
+import ShortLinkForm, { type ShortLinkFormData } from './Partials/ShortLinkForm'
+
+export default function Create() {
+  const { data, setData, post, processing, errors } = useForm<ShortLinkFormData>({
+    destination_url: '',
+    code: '',
+    title: '',
+    expires_at: '',
+    is_active: true,
+  })
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    post('/admin/short')
+  }
+
+  return (
+    <AuthenticatedLayout
+      header={<h2 className="text-xl font-semibold leading-tight text-gray-800">New Short Link</h2>}
+    >
+      <Head title="New Short Link" />
+
+      <div className="py-6 sm:py-12">
+        <div className="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8">
+          <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm sm:p-8">
+            <ShortLinkForm
+              data={data}
+              setData={setData}
+              errors={errors}
+              processing={processing}
+              onSubmit={submit}
+              submitLabel="Create short link"
+            />
+          </div>
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  )
+}

--- a/resources/js/Pages/Admin/Short/Edit.tsx
+++ b/resources/js/Pages/Admin/Short/Edit.tsx
@@ -1,0 +1,52 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout'
+import { Head, useForm } from '@inertiajs/react'
+import ShortLinkForm, { type ShortLinkFormData } from './Partials/ShortLinkForm'
+
+interface ShortLinkRecord {
+  id: number
+  code: string
+  destination_url: string
+  title: string | null
+  short_url: string
+  is_active: boolean
+  expires_at: string | null
+}
+
+export default function Edit({ link }: { link: ShortLinkRecord }) {
+  const { data, setData, put, processing, errors } = useForm<ShortLinkFormData>({
+    destination_url: link.destination_url,
+    code: link.code,
+    title: link.title ?? '',
+    expires_at: link.expires_at ?? '',
+    is_active: link.is_active,
+  })
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    put(`/admin/short/${link.id}`)
+  }
+
+  return (
+    <AuthenticatedLayout
+      header={<h2 className="text-xl font-semibold leading-tight text-gray-800">Edit Short Link</h2>}
+    >
+      <Head title={`Edit · ${link.code}`} />
+
+      <div className="py-6 sm:py-12">
+        <div className="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8">
+          <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm sm:p-8">
+            <ShortLinkForm
+              data={data}
+              setData={setData}
+              errors={errors}
+              processing={processing}
+              onSubmit={submit}
+              submitLabel="Save changes"
+              shortUrl={link.short_url}
+            />
+          </div>
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  )
+}

--- a/resources/js/Pages/Admin/Short/Index.tsx
+++ b/resources/js/Pages/Admin/Short/Index.tsx
@@ -1,0 +1,160 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout'
+import { Head, Link, router } from '@inertiajs/react'
+import { useState } from 'react'
+import { BarChart3, Check, Copy, ExternalLink, Pencil, Plus, Trash2 } from 'lucide-react'
+
+interface ShortLinkRecord {
+  id: number
+  code: string
+  destination_url: string
+  title: string | null
+  short_url: string
+  is_active: boolean
+  expires_at: string | null
+  clicks_count: number
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      title={copied ? 'Copied' : 'Copy short URL'}
+      className="rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+    >
+      {copied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+    </button>
+  )
+}
+
+export default function Index({ links }: { links: ShortLinkRecord[] }) {
+  const toggleActive = (link: ShortLinkRecord) => {
+    router.patch(`/admin/short/${link.id}/toggle`, {}, { preserveScroll: true })
+  }
+
+  const destroy = (link: ShortLinkRecord) => {
+    if (!confirm(`Delete "${link.short_url}"? This cannot be undone.`)) return
+    router.delete(`/admin/short/${link.id}`, { preserveScroll: true })
+  }
+
+  return (
+    <AuthenticatedLayout
+      header={<h2 className="text-xl font-semibold leading-tight text-gray-800">Short Links</h2>}
+    >
+      <Head title="Short Links" />
+
+      <div className="py-6 sm:py-12">
+        <div className="mx-auto max-w-4xl space-y-4 px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-sm text-gray-500">
+              Share the short link instead of the raw one to see who clicks it and where they come from.
+            </p>
+            <div className="flex shrink-0 items-center gap-2">
+              <Link
+                href="/admin/short/analytics"
+                className="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-gray-700 ring-1 ring-gray-200 transition hover:bg-gray-50"
+              >
+                <BarChart3 className="h-4 w-4" />
+                Analytics
+              </Link>
+              <Link
+                href="/admin/short/create"
+                className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-700"
+              >
+                <Plus className="h-4 w-4" />
+                New short link
+              </Link>
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            {links.length === 0 ? (
+              <div className="px-6 py-16 text-center">
+                <p className="text-sm text-gray-500">No short links yet.</p>
+                <Link href="/admin/short/create" className="mt-2 inline-block text-sm font-medium text-indigo-600 hover:underline">
+                  Create your first one
+                </Link>
+              </div>
+            ) : (
+              <ul className="divide-y divide-gray-100">
+                {links.map((link) => (
+                  <li key={link.id} className="flex items-center gap-3 px-3 py-3 hover:bg-gray-50 sm:px-4">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-gray-900">
+                        {link.short_url.replace(/^https?:\/\//, '')}
+                        {link.title && <span className="ml-2 font-normal text-gray-400">{link.title}</span>}
+                      </p>
+                      <p className="truncate text-xs text-gray-400">{link.destination_url}</p>
+                    </div>
+
+                    <span
+                      className="hidden shrink-0 text-xs tabular-nums text-gray-400 sm:inline"
+                      title="Total clicks"
+                    >
+                      {link.clicks_count}
+                    </span>
+
+                    <button
+                      type="button"
+                      onClick={() => toggleActive(link)}
+                      role="switch"
+                      aria-checked={link.is_active}
+                      title={link.is_active ? 'Active, click to disable' : 'Disabled, click to enable'}
+                      className={
+                        'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition ' +
+                        (link.is_active ? 'bg-emerald-500' : 'bg-gray-300')
+                      }
+                    >
+                      <span
+                        className={
+                          'inline-block h-5 w-5 transform rounded-full bg-white shadow transition ' +
+                          (link.is_active ? 'translate-x-5' : 'translate-x-0.5')
+                        }
+                      />
+                    </button>
+
+                    <div className="flex shrink-0 items-center gap-1">
+                      <CopyButton text={link.short_url} />
+                      <a
+                        href={link.destination_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="Open destination"
+                        className="rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </a>
+                      <Link
+                        href={`/admin/short/${link.id}/edit`}
+                        title="Edit"
+                        className="rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => destroy(link)}
+                        title="Delete"
+                        className="rounded-md p-2 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  )
+}

--- a/resources/js/Pages/Admin/Short/Partials/ShortLinkForm.tsx
+++ b/resources/js/Pages/Admin/Short/Partials/ShortLinkForm.tsx
@@ -1,0 +1,115 @@
+import InputError from '@/Components/InputError'
+import InputLabel from '@/Components/InputLabel'
+import PrimaryButton from '@/Components/PrimaryButton'
+import TextInput from '@/Components/TextInput'
+import { Link } from '@inertiajs/react'
+
+export interface ShortLinkFormData {
+  destination_url: string
+  code: string
+  title: string
+  expires_at: string
+  is_active: boolean
+  [key: string]: string | boolean
+}
+
+interface Props {
+  data: ShortLinkFormData
+  setData: (key: keyof ShortLinkFormData, value: string | boolean) => void
+  errors: Partial<Record<keyof ShortLinkFormData, string>>
+  processing: boolean
+  onSubmit: (e: React.FormEvent) => void
+  submitLabel: string
+  /** Shown once a code exists (edit only) -- there's nothing to preview on create. */
+  shortUrl?: string | null
+}
+
+export default function ShortLinkForm({
+  data,
+  setData,
+  errors,
+  processing,
+  onSubmit,
+  submitLabel,
+  shortUrl = null,
+}: Props) {
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      <div>
+        <InputLabel htmlFor="destination_url" value="Destination URL" />
+        <TextInput
+          id="destination_url"
+          type="text"
+          className="mt-1 block w-full"
+          value={data.destination_url}
+          onChange={(e) => setData('destination_url', e.target.value)}
+          placeholder="https://example.com/the-real-page"
+          isFocused
+          required
+        />
+        <InputError message={errors.destination_url} className="mt-2" />
+      </div>
+
+      <div>
+        <InputLabel htmlFor="code" value="Custom code (optional)" />
+        <TextInput
+          id="code"
+          className="mt-1 block w-full"
+          value={data.code}
+          onChange={(e) => setData('code', e.target.value)}
+          placeholder="leave blank to generate one"
+        />
+        {shortUrl ? (
+          <p className="mt-1 text-xs text-gray-400">
+            Live at <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-indigo-600">{shortUrl}</code>
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-gray-500">Letters, numbers, dashes and underscores only.</p>
+        )}
+        <InputError message={errors.code} className="mt-2" />
+      </div>
+
+      <div>
+        <InputLabel htmlFor="title" value="Title (optional)" />
+        <TextInput
+          id="title"
+          className="mt-1 block w-full"
+          value={data.title}
+          onChange={(e) => setData('title', e.target.value)}
+          placeholder="A note to tell this link apart from the rest"
+        />
+        <InputError message={errors.title} className="mt-2" />
+      </div>
+
+      <div>
+        <InputLabel htmlFor="expires_at" value="Expires at (optional)" />
+        <TextInput
+          id="expires_at"
+          type="datetime-local"
+          className="mt-1 block w-full"
+          value={data.expires_at}
+          onChange={(e) => setData('expires_at', e.target.value)}
+        />
+        <p className="mt-1 text-xs text-gray-500">Leave blank to never expire. Expired links 404 instead of redirecting.</p>
+        <InputError message={errors.expires_at} className="mt-2" />
+      </div>
+
+      <label className="flex items-center gap-3">
+        <input
+          type="checkbox"
+          checked={data.is_active}
+          onChange={(e) => setData('is_active', e.target.checked)}
+          className="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+        />
+        <span className="text-sm text-gray-700">Active (redirects visitors)</span>
+      </label>
+
+      <div className="flex items-center gap-4 pt-2">
+        <PrimaryButton disabled={processing}>{submitLabel}</PrimaryButton>
+        <Link href="/admin/short" className="text-sm text-gray-600 hover:text-gray-900">
+          Cancel
+        </Link>
+      </div>
+    </form>
+  )
+}

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -175,12 +175,18 @@ export default function Dashboard({ stats, recentPosts, draftPostsList }: Props)
                         <div className="px-4 sm:px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
                             <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Quick Actions</h3>
                         </div>
-                        <div className="px-4 sm:px-6 py-4">
+                        <div className="px-4 sm:px-6 py-4 flex flex-wrap gap-3">
                             <Link
                                 href="/admin"
                                 className="inline-flex items-center px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
                             >
                                 View All Posts
+                            </Link>
+                            <Link
+                                href="/admin/short"
+                                className="inline-flex items-center px-4 py-2 bg-white text-neutral-700 text-sm font-medium rounded-lg border border-neutral-200 hover:bg-neutral-50 transition-colors dark:bg-neutral-800 dark:text-neutral-200 dark:border-neutral-700 dark:hover:bg-neutral-700/50"
+                            >
+                                Short Links
                             </Link>
                         </div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,7 +4,10 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\BlogCommentController;
 use App\Http\Controllers\Admin\BioLinkController;
+use App\Http\Controllers\Admin\ShortLinkController;
 use App\Models\BioLink;
+use App\Models\ShortLink;
+use App\Models\ShortLinkClick;
 use App\Models\BlogCommentThread;
 use App\Support\BlogRepository;
 use App\Support\CaseStudyRepository;
@@ -103,6 +106,39 @@ Route::middleware(['auth', 'verified', 'role:admin'])
         Route::patch('/{bioLink}/toggle', [BioLinkController::class, 'toggle'])->name('toggle');
         Route::delete('/{bioLink}', [BioLinkController::class, 'destroy'])->name('destroy');
     });
+
+// Admin CRUD for the URL shortener
+Route::middleware(['auth', 'verified', 'role:admin'])
+    ->prefix('admin/short')
+    ->name('admin.short.')
+    ->group(function () {
+        Route::get('/', [ShortLinkController::class, 'index'])->name('index');
+        Route::get('/analytics', [ShortLinkController::class, 'analytics'])->name('analytics');
+        Route::get('/create', [ShortLinkController::class, 'create'])->name('create');
+        Route::post('/', [ShortLinkController::class, 'store'])->name('store');
+        Route::get('/{shortLink}/edit', [ShortLinkController::class, 'edit'])->name('edit');
+        Route::put('/{shortLink}', [ShortLinkController::class, 'update'])->name('update');
+        Route::patch('/{shortLink}/toggle', [ShortLinkController::class, 'toggle'])->name('toggle');
+        Route::delete('/{shortLink}', [ShortLinkController::class, 'destroy'])->name('destroy');
+    });
+
+// Public short-link redirect + click tracking (no auth needed). 302 so
+// browsers/CDNs never cache the redirect and skip recording a hit.
+Route::get('/s/{code}', function (string $code, Request $request, CountryResolver $countries) {
+    $link = ShortLink::query()->active()->where('code', $code)->first();
+
+    abort_unless($link, 404);
+
+    ShortLinkClick::create([
+        'short_link_id' => $link->id,
+        'ip_address' => $request->ip(),
+        'country' => $countries->resolve($request->ip()),
+        'user_agent' => $request->userAgent(),
+        'referer' => $request->header('referer'),
+    ]);
+
+    return redirect()->away($link->destination_url, 302);
+})->name('short.redirect');
 
 // Public link-in-bio landing page (DB-driven, no auth)
 Route::get('/bio', function (Request $request, CountryResolver $countries) {

--- a/tests/Feature/ShortLinkTest.php
+++ b/tests/Feature/ShortLinkTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ShortLink;
+use App\Models\ShortLinkClick;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShortLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        return User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => 'admin',
+        ]);
+    }
+
+    public function test_visiting_a_short_link_redirects_and_records_a_click(): void
+    {
+        $link = ShortLink::create(['destination_url' => 'https://example.com/target']);
+
+        $this->get("/s/{$link->code}")
+            ->assertRedirect('https://example.com/target')
+            ->assertStatus(302);
+
+        $this->assertDatabaseCount('short_link_clicks', 1);
+        $this->assertSame($link->id, ShortLinkClick::first()->short_link_id);
+    }
+
+    public function test_an_inactive_link_404s(): void
+    {
+        $link = ShortLink::create([
+            'destination_url' => 'https://example.com/target',
+            'is_active' => false,
+        ]);
+
+        $this->get("/s/{$link->code}")->assertNotFound();
+        $this->assertDatabaseCount('short_link_clicks', 0);
+    }
+
+    public function test_an_expired_link_404s(): void
+    {
+        $link = ShortLink::create([
+            'destination_url' => 'https://example.com/target',
+            'expires_at' => now()->subDay(),
+        ]);
+
+        $this->get("/s/{$link->code}")->assertNotFound();
+        $this->assertDatabaseCount('short_link_clicks', 0);
+    }
+
+    public function test_an_unknown_code_404s(): void
+    {
+        $this->get('/s/does-not-exist')->assertNotFound();
+    }
+
+    public function test_a_custom_code_round_trips(): void
+    {
+        $this->actingAs($this->admin())
+            ->post('/admin/short', [
+                'destination_url' => 'https://example.com/target',
+                'code' => 'my-code',
+                'is_active' => true,
+            ])
+            ->assertRedirect('/admin/short');
+
+        $this->assertDatabaseHas('short_links', ['code' => 'my-code']);
+
+        $this->get('/s/my-code')->assertRedirect('https://example.com/target');
+    }
+
+    public function test_a_duplicate_custom_code_is_rejected(): void
+    {
+        ShortLink::create(['destination_url' => 'https://example.com/one', 'code' => 'taken']);
+
+        $this->actingAs($this->admin())
+            ->post('/admin/short', [
+                'destination_url' => 'https://example.com/two',
+                'code' => 'taken',
+                'is_active' => true,
+            ])
+            ->assertSessionHasErrors('code');
+    }
+
+    public function test_a_blank_code_is_auto_generated(): void
+    {
+        $link = ShortLink::create(['destination_url' => 'https://example.com/target']);
+
+        $this->assertNotEmpty($link->code);
+        $this->assertSame(7, strlen($link->code));
+    }
+
+    public function test_admin_routes_require_authentication(): void
+    {
+        $this->get('/admin/short')->assertRedirect('/login');
+    }
+}


### PR DESCRIPTION
## Summary
- New `harun.dev/s/{code}` shortener: create/manage links in admin, redirect + track every click (country, referer, user agent), aggregate and per-link analytics
- Mirrors the existing bio-link click-tracking pattern (`ShortLink`/`ShortLinkClick`, `Admin/ShortLinkController`, `Admin/Short/*` pages)
- Bio links are untouched

## Test plan
- [x] `php artisan migrate` clean locally
- [x] `tests/Feature/ShortLinkTest.php` — 8 tests, 21 assertions, all passing (redirect+tracking, inactive/expired 404, custom code round-trip + dup rejection, auto-generated code, auth gating)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Live browser click-through: create a link in admin, visit `/s/{code}` in a second tab, confirm redirect, click count, and analytics all update
- [x] No em dashes in new copy

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin short-link management, including creation, editing, deletion, activation controls, custom codes, expiration dates, and destination URLs.
  * Added public short-link redirects with click tracking.
  * Added analytics for clicks over time, links, countries, and referrers, with 7-, 30-, and 90-day filters.
  * Added dashboard access to Short Links and copy-link actions.
* **Bug Fixes**
  * Inactive, expired, or unknown short links now return a not-found response.
* **Tests**
  * Added coverage for redirects, tracking, validation, code generation, expiration, and admin access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->