### PR TITLE
Route bio links through the shortener, with dedup and self-detection

### DIFF
--- a/app/Http/Controllers/Admin/ShortLinkController.php
+++ b/app/Http/Controllers/Admin/ShortLinkController.php
@@ -155,6 +155,16 @@ class ShortLinkController extends Controller
     {
         $data = $this->validateData($request);
 
+        // A blank code means "just shorten this URL" -- check for an existing
+        // link first so the same destination doesn't end up with two codes.
+        // A custom code is a deliberate vanity alias, so it always creates.
+        if (empty($data['code']) && ShortLink::findForUrl($data['destination_url'])) {
+            return redirect()->route('admin.short.index')->with('flash', [
+                'type' => 'info',
+                'message' => 'That URL is already shortened, so we reused the existing link.',
+            ]);
+        }
+
         ShortLink::create($data);
 
         return redirect()->route('admin.short.index')->with('flash', [

--- a/app/Models/BioLink.php
+++ b/app/Models/BioLink.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -13,6 +14,7 @@ class BioLink extends Model
     protected $fillable = [
         'label',
         'url',
+        'short_link_id',
         'tab',
         'tab_slug',
         'icon',
@@ -50,6 +52,15 @@ class BioLink extends Model
                 $tab = $link->tab ?? 'default';
                 $link->tab_slug = $tab === 'default' ? 'default' : Str::slug($tab);
             }
+
+            // Resolve (or reuse) a short link whenever the destination changes,
+            // so every bio link points visitors through /s/{code} instead of
+            // straight at the raw URL. Internal routes and mailto: come back
+            // null from getOrCreateForUrl, which clears any short link a since
+            // edited URL no longer needs one.
+            if ($link->isDirty('url')) {
+                $link->short_link_id = ShortLink::getOrCreateForUrl($link->url, $link->label)?->id;
+            }
         });
     }
 
@@ -65,6 +76,11 @@ class BioLink extends Model
     public function clicks(): HasMany
     {
         return $this->hasMany(BioLinkClick::class);
+    }
+
+    public function shortLink(): BelongsTo
+    {
+        return $this->belongsTo(ShortLink::class);
     }
 
     /**

--- a/app/Models/ShortLink.php
+++ b/app/Models/ShortLink.php
@@ -12,6 +12,7 @@ class ShortLink extends Model
     protected $fillable = [
         'code',
         'destination_url',
+        'url_hash',
         'title',
         'is_active',
         'expires_at',
@@ -31,6 +32,90 @@ class ShortLink extends Model
                 $link->code = static::generateUniqueCode();
             }
         });
+
+        static::saving(function (self $link) {
+            if ($link->isDirty('destination_url')) {
+                $link->url_hash = static::hashFor($link->destination_url);
+            }
+        });
+    }
+
+    /**
+     * Trim and lowercase the scheme/host so trivial variants (a trailing
+     * slash, mixed-case host, http vs. HTTP) hash the same, without touching
+     * path/query/fragment -- those can be case-sensitive and genuinely change
+     * the destination.
+     */
+    public static function normalizeUrl(string $url): string
+    {
+        $url = trim($url);
+        $parts = parse_url($url);
+
+        if (! $parts || ! isset($parts['scheme'], $parts['host'])) {
+            return $url;
+        }
+
+        $scheme = strtolower($parts['scheme']);
+        $host = strtolower($parts['host']);
+        $port = isset($parts['port']) ? ':'.$parts['port'] : '';
+        $path = isset($parts['path']) ? rtrim($parts['path'], '/') : '';
+        $query = isset($parts['query']) ? '?'.$parts['query'] : '';
+        $fragment = isset($parts['fragment']) ? '#'.$parts['fragment'] : '';
+
+        return "{$scheme}://{$host}{$port}{$path}{$query}{$fragment}";
+    }
+
+    public static function hashFor(string $url): string
+    {
+        return hash('sha256', static::normalizeUrl($url));
+    }
+
+    /**
+     * Look up a link for $url without creating one -- the shared detection
+     * both getOrCreateForUrl() and the admin dedup check build on.
+     *
+     * Returns null for anything that isn't worth shortening (internal
+     * routes, mailto:, tel:), or when nothing matches yet. Otherwise: if the
+     * URL is already one of our own /s/{code} links, that link. Failing
+     * that, any existing link with the same normalized URL.
+     */
+    public static function findForUrl(string $url): ?self
+    {
+        $parts = parse_url($url);
+
+        if (! $parts || ! in_array($parts['scheme'] ?? null, ['http', 'https'], true)) {
+            return null;
+        }
+
+        $ourHost = parse_url(config('app.url'), PHP_URL_HOST);
+
+        if ($ourHost && strcasecmp($parts['host'] ?? '', $ourHost) === 0
+            && preg_match('#^/s/([^/]+)/?$#', $parts['path'] ?? '', $match)) {
+            $existing = static::where('code', $match[1])->first();
+
+            if ($existing) {
+                return $existing;
+            }
+        }
+
+        return static::where('url_hash', static::hashFor($url))->first();
+    }
+
+    /**
+     * The single place both the bio-link saving hook and the admin "create
+     * short link" form go through, so a URL never gets shortened twice.
+     * Reuses whatever findForUrl() turns up; only creates when nothing does.
+     */
+    public static function getOrCreateForUrl(string $url, ?string $title = null): ?self
+    {
+        if (! preg_match('#^https?://#i', $url)) {
+            return null;
+        }
+
+        return static::findForUrl($url) ?? static::create([
+            'destination_url' => $url,
+            'title' => $title,
+        ]);
     }
 
     /**

--- a/database/migrations/2026_07_22_093000_add_url_hash_to_short_links_table.php
+++ b/database/migrations/2026_07_22_093000_add_url_hash_to_short_links_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\ShortLink;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('short_links', function (Blueprint $table) {
+            $table->string('url_hash', 64)->nullable()->after('destination_url');
+            $table->index('url_hash');
+        });
+
+        // Backfill existing rows so dedup lookups work retroactively, not just
+        // for links created after this migration.
+        ShortLink::query()->each(function (ShortLink $link) {
+            $link->url_hash = ShortLink::hashFor($link->destination_url);
+            $link->saveQuietly();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('short_links', function (Blueprint $table) {
+            $table->dropIndex(['url_hash']);
+            $table->dropColumn('url_hash');
+        });
+    }
+};

--- a/database/migrations/2026_07_22_093001_add_short_link_id_to_bio_links_table.php
+++ b/database/migrations/2026_07_22_093001_add_short_link_id_to_bio_links_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\BioLink;
+use App\Models\ShortLink;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bio_links', function (Blueprint $table) {
+            $table->foreignId('short_link_id')->nullable()->after('url')
+                ->constrained('short_links')->nullOnDelete();
+        });
+
+        // Backfill: give every existing external bio link a short link so
+        // clicks start routing through /s/{code} without waiting on an edit.
+        BioLink::query()->each(function (BioLink $link) {
+            $shortLink = ShortLink::getOrCreateForUrl($link->url, $link->label);
+
+            if ($shortLink) {
+                $link->short_link_id = $shortLink->id;
+                $link->saveQuietly();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bio_links', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('short_link_id');
+        });
+    }
+};

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -12,6 +12,7 @@ interface BioLink {
   id: number
   label: string
   url: string
+  share_url: string
   icon: string
   thumbnail_url: string | null
   featured: boolean
@@ -140,7 +141,7 @@ function LinkAnchor({ link, className }: { link: BioLink; className: string }) {
 
   return (
     <a
-      href={link.url}
+      href={link.share_url}
       target={mailish ? undefined : '_blank'}
       rel={mailish ? undefined : 'noopener noreferrer'}
       onClick={() => trackClick(link.id)}
@@ -378,7 +379,7 @@ function ShareTrigger({
       </button>
       {isOpen && (
         <div className="absolute right-0 top-full z-30 mt-2">
-          <ShareSheet title={link.label} url={link.url} shareTitle={link.label} onClose={onClose} />
+          <ShareSheet title={link.label} url={link.share_url} shareTitle={link.label} onClose={onClose} />
         </div>
       )}
     </div>
@@ -582,7 +583,7 @@ export default function Bio({ links = [] }: { links?: BioLink[] }) {
                   return (
                     <a
                       key={link.id}
-                      href={link.url}
+                      href={link.share_url}
                       target="_blank"
                       rel="noopener noreferrer"
                       onClick={() => trackClick(link.id)}

--- a/routes/web.php
+++ b/routes/web.php
@@ -148,13 +148,15 @@ Route::get('/bio', function (Request $request, CountryResolver $countries) {
         ->active()
         ->orderBy('priority')
         ->orderBy('id')
-        ->get(['id', 'label', 'url', 'icon', 'thumbnail_path', 'featured', 'tab', 'tab_slug', 'include_countries', 'exclude_countries'])
+        ->get(['id', 'label', 'url', 'short_link_id', 'icon', 'thumbnail_path', 'featured', 'tab', 'tab_slug', 'include_countries', 'exclude_countries'])
+        ->load('shortLink:id,code')
         ->filter(fn (BioLink $link) => $link->isVisibleInCountry($country))
         ->values()
         ->map(fn (BioLink $link) => [
             'id' => $link->id,
             'label' => $link->label,
             'url' => $link->url,
+            'share_url' => $link->shortLink?->short_url ?? $link->url,
             'icon' => $link->icon,
             'thumbnail_url' => $link->thumbnail_url,
             'featured' => (bool) $link->featured,

--- a/tests/Feature/BioLinkShortLinkTest.php
+++ b/tests/Feature/BioLinkShortLinkTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\BioLink;
+use App\Models\ShortLink;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BioLinkShortLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_saving_a_bio_link_with_an_external_url_resolves_a_short_link(): void
+    {
+        $link = BioLink::create([
+            'label' => 'Blog',
+            'url' => 'https://example.com/blog',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+
+        $this->assertNotNull($link->short_link_id);
+        $this->assertSame('https://example.com/blog', $link->shortLink->destination_url);
+    }
+
+    public function test_saving_a_bio_link_with_an_internal_url_leaves_short_link_null(): void
+    {
+        $link = BioLink::create([
+            'label' => 'Contact',
+            'url' => '/contact',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+
+        $this->assertNull($link->short_link_id);
+    }
+
+    public function test_two_bio_links_to_the_same_destination_share_one_short_link(): void
+    {
+        $first = BioLink::create([
+            'label' => 'Blog',
+            'url' => 'https://example.com/blog',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+
+        $second = BioLink::create([
+            'label' => 'Blog Again',
+            'url' => 'https://example.com/blog',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+
+        $this->assertSame($first->short_link_id, $second->short_link_id);
+        $this->assertSame(1, ShortLink::count());
+    }
+
+    public function test_editing_a_bio_link_url_re_points_the_short_link(): void
+    {
+        $link = BioLink::create([
+            'label' => 'Blog',
+            'url' => 'https://example.com/blog',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+        $original = $link->short_link_id;
+
+        $link->update(['url' => 'https://example.com/newsletter']);
+
+        $this->assertNotSame($original, $link->short_link_id);
+        $this->assertSame('https://example.com/newsletter', $link->shortLink->destination_url);
+    }
+
+    public function test_editing_a_bio_link_url_to_internal_clears_the_short_link(): void
+    {
+        $link = BioLink::create([
+            'label' => 'Blog',
+            'url' => 'https://example.com/blog',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+
+        $link->update(['url' => '/contact']);
+
+        $this->assertNull($link->short_link_id);
+    }
+
+    public function test_the_bio_page_exposes_the_short_url_as_share_url(): void
+    {
+        BioLink::create([
+            'label' => 'Blog',
+            'url' => 'https://example.com/blog',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+        BioLink::create([
+            'label' => 'Contact',
+            'url' => '/contact',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+
+        $props = $this->get('/bio')->assertOk()->viewData('page')['props'];
+
+        $byLabel = collect($props['links'])->keyBy('label');
+
+        $this->assertStringContainsString('/s/', $byLabel['Blog']['share_url']);
+        $this->assertSame('https://example.com/blog', $byLabel['Blog']['url']);
+
+        // Internal links have nothing to shorten -- share_url just mirrors url.
+        $this->assertSame('/contact', $byLabel['Contact']['share_url']);
+    }
+}

--- a/tests/Feature/ShortLinkTest.php
+++ b/tests/Feature/ShortLinkTest.php
@@ -99,4 +99,46 @@ class ShortLinkTest extends TestCase
     {
         $this->get('/admin/short')->assertRedirect('/login');
     }
+
+    public function test_get_or_create_for_url_reuses_an_existing_link_for_the_same_destination(): void
+    {
+        $first = ShortLink::getOrCreateForUrl('https://example.com/path');
+        $second = ShortLink::getOrCreateForUrl('https://EXAMPLE.com/path/');
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame(1, ShortLink::count());
+    }
+
+    public function test_get_or_create_for_url_detects_one_of_our_own_short_urls(): void
+    {
+        $link = ShortLink::create(['destination_url' => 'https://example.com/target']);
+
+        $reused = ShortLink::getOrCreateForUrl($link->short_url);
+
+        $this->assertSame($link->id, $reused->id);
+        $this->assertSame(1, ShortLink::count());
+    }
+
+    public function test_get_or_create_for_url_returns_null_for_internal_and_mailto_urls(): void
+    {
+        $this->assertNull(ShortLink::getOrCreateForUrl('/bio'));
+        $this->assertNull(ShortLink::getOrCreateForUrl('mailto:harun@harun.dev'));
+        $this->assertSame(0, ShortLink::count());
+    }
+
+    public function test_creating_via_admin_with_an_already_shortened_url_reuses_it(): void
+    {
+        $existing = ShortLink::create(['destination_url' => 'https://example.com/target']);
+
+        $this->actingAs($this->admin())
+            ->post('/admin/short', [
+                'destination_url' => 'https://example.com/target',
+                'is_active' => true,
+            ])
+            ->assertRedirect('/admin/short')
+            ->assertSessionHas('flash.type', 'info');
+
+        $this->assertSame(1, ShortLink::count());
+        $this->assertSame($existing->code, ShortLink::first()->code);
+    }
 }


### PR DESCRIPTION
## Summary
- Bio link cards, per-link shares, and the social icon row now open and share the short URL (`/s/{code}`) instead of the raw destination, so both clicks and reshares are attributable in short-link analytics.
- `BioLink` resolves (or reuses) a short link on save via a model hook; `ShortLink::getOrCreateForUrl()` normalizes and hashes the destination URL so the same link is never shortened twice, and detects when a destination is already one of our own `/s/{code}` URLs.
- Admin's "create short link" form applies the same dedup check and reuses an existing link instead of creating a duplicate.
- Both migrations backfill existing rows (`url_hash` on `short_links`, `short_link_id` on `bio_links`).

## Test plan
- [x] `php artisan migrate --force` clean locally, backfill populated `url_hash` and `short_link_id` correctly
- [x] New feature tests (dedup, self-detection, internal/mailto exclusion, saving-hook behavior, `/bio` payload `share_url`, admin dedup-reuse) pass
- [x] Full test suite green except 7 pre-existing unrelated failures (confirmed present on `main` before this change too)
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] Browser: link card hrefs are `/s/{code}`, clicking through redirects and records both `bio_link_clicks` and `short_link_clicks`, per-link Share sheet's QR/social intents use the short URL, favicons still show the real destination's icon
- [x] `grep "—"` over all changed/new files: clean

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic short-link creation and reuse for external Bio links.
  * Bio pages now use short URLs for sharing, copying, QR codes, and social links.
  * Reusing an existing short link now displays an informational message.
  * Updated links automatically reflect destination URL changes.

* **Bug Fixes**
  * Prevented duplicate short links for equivalent URLs.
  * Internal and non-web links are no longer shortened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->