### PR TITLE
Fix wrong LinkedIn URL on the bio page

### DIFF
--- a/database/migrations/2026_07_22_095701_fix_linkedin_bio_link_url.php
+++ b/database/migrations/2026_07_22_095701_fix_linkedin_bio_link_url.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\BioLink;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    private const WRONG_URL = 'https://linkedin.com/in/harunrayhan';
+
+    private const CORRECT_URL = 'https://www.linkedin.com/in/harunrrayhan/';
+
+    public function up(): void
+    {
+        BioLink::where('url', self::WRONG_URL)
+            ->each(fn (BioLink $link) => $link->update(['url' => self::CORRECT_URL]));
+    }
+
+    public function down(): void
+    {
+        BioLink::where('url', self::CORRECT_URL)
+            ->each(fn (BioLink $link) => $link->update(['url' => self::WRONG_URL]));
+    }
+};


### PR DESCRIPTION
## Summary
- The LinkedIn bio link's URL was already wrong in the database (`https://linkedin.com/in/harunrayhan`, missing `www.` and a letter), predating the shortener work. It only surfaced now that the link routes through `/s/{code}`.
- Data-fix migration corrects it to `https://www.linkedin.com/in/harunrrayhan/`, going through the model's normal update path so a correct short link gets resolved.
- Verified all other social links (Twitter, GitHub, Facebook, Instagram, TikTok, Threads) already resolve correct short URLs — no gap there.

## Test plan
- [x] Migration runs clean locally
- [x] Tinker sanity check: updating the URL re-points to a new, correct short link
- [x] `BioLinkShortLinkTest` + `ShortLinkTest` pass (18/18)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE