### PR TITLE
Shorten bio share links, drop subtitle Enthusiast

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -386,9 +386,21 @@ function ShareTrigger({
   )
 }
 
-export default function Bio({ links = [] }: { links?: BioLink[] }) {
+export default function Bio({
+  links = [],
+  page_share_url: pageShareUrl,
+  tab_share_urls: tabShareUrls = {},
+}: {
+  links?: BioLink[]
+  page_share_url?: string
+  tab_share_urls?: Record<string, string>
+}) {
   const { url } = usePage()
+  // Real page URL — feeds SEO tags (og:url, canonical). Must stay the actual
+  // page, never the shortener redirect.
   const canonicalUrl = typeof window !== 'undefined' ? window.location.href : 'https://harun.dev/bio'
+  // Shortened page URL for the "Share this page" sheet's QR/copy/social links.
+  const pageShareLinkUrl = pageShareUrl ?? canonicalUrl
 
   // Separate social (icon-only row) from regular (tabbed) links. Website and
   // email are pulled out and appended last, in a fixed order, regardless of
@@ -464,10 +476,11 @@ export default function Bio({ links = [] }: { links?: BioLink[] }) {
 
   const tabShareUrl = useCallback(
     (slug: string) => {
+      if (tabShareUrls[slug]) return tabShareUrls[slug]
       const base = window.location.origin + window.location.pathname
       return slug === tabGroups[0]?.slug ? base : `${base}?tab=${encodeURIComponent(slug)}`
     },
-    [tabGroups],
+    [tabGroups, tabShareUrls],
   )
 
   // Close whichever share menu is open on an outside click or Escape.
@@ -541,7 +554,7 @@ export default function Bio({ links = [] }: { links?: BioLink[] }) {
             </button>
             {openMenu === 'page' && (
               <div className="absolute right-0 top-full z-30 mt-2">
-                <ShareSheet title="Share this page" url={canonicalUrl} shareTitle="Harun R. Rayhan" onClose={() => setOpenMenu(null)} />
+                <ShareSheet title="Share this page" url={pageShareLinkUrl} shareTitle="Harun R. Rayhan" onClose={() => setOpenMenu(null)} />
               </div>
             )}
           </div>
@@ -570,7 +583,7 @@ export default function Bio({ links = [] }: { links?: BioLink[] }) {
                 Software Engineer turning Entrepreneur
               </p>
               <p className="font-mono text-xs text-[#6b5d4f] sm:text-sm">
-                DevOps · AI/ML Enthusiast · AWS · CloudOps · Infrastructure Automation
+                DevOps · AI/ML · AWS · CloudOps · Infrastructure Automation
               </p>
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -165,7 +165,22 @@ Route::get('/bio', function (Request $request, CountryResolver $countries) {
         ])
         ->all();
 
-    return Inertia::render('Bio', ['links' => $links]);
+    $pageShareUrl = ShortLink::getOrCreateForUrl(url('/bio'), 'Bio page')?->short_url ?? url('/bio');
+
+    $tabShareUrls = collect($links)
+        ->pluck('tab_slug')
+        ->unique()
+        ->mapWithKeys(function (string $slug) {
+            $tabUrl = url('/bio').'?tab='.$slug;
+
+            return [$slug => ShortLink::getOrCreateForUrl($tabUrl, "Bio: {$slug}")?->short_url ?? $tabUrl];
+        });
+
+    return Inertia::render('Bio', [
+        'links' => $links,
+        'page_share_url' => $pageShareUrl,
+        'tab_share_urls' => $tabShareUrls,
+    ]);
 });
 
 // Click tracking for bio links (no auth needed)

--- a/tests/Feature/BioLinkShortLinkTest.php
+++ b/tests/Feature/BioLinkShortLinkTest.php
@@ -111,4 +111,27 @@ class BioLinkShortLinkTest extends TestCase
         // Internal links have nothing to shorten -- share_url just mirrors url.
         $this->assertSame('/contact', $byLabel['Contact']['share_url']);
     }
+
+    public function test_the_bio_page_exposes_short_urls_for_the_page_and_each_tab(): void
+    {
+        BioLink::create([
+            'label' => 'Blog',
+            'url' => 'https://example.com/blog',
+            'icon' => 'link',
+            'tab' => 'default',
+        ]);
+        BioLink::create([
+            'label' => 'Shop',
+            'url' => 'https://example.com/shop',
+            'icon' => 'link',
+            'tab' => 'Products',
+        ]);
+
+        $props = $this->get('/bio')->assertOk()->viewData('page')['props'];
+
+        $this->assertStringContainsString('/s/', $props['page_share_url']);
+        $this->assertStringContainsString('/s/', $props['tab_share_urls']['default']);
+        $this->assertStringContainsString('/s/', $props['tab_share_urls']['products']);
+        $this->assertNotSame($props['tab_share_urls']['default'], $props['tab_share_urls']['products']);
+    }
 }


### PR DESCRIPTION
## Summary
- Remove "Enthusiast" from the bio page subtitle
- Whole-page and per-tab Share sheets now use shortened `/s/{code}` links (QR, native share, copy link, social icons) instead of the raw bio URL, reusing `ShortLink::getOrCreateForUrl`
- SEO tags (`og:url`, canonical) stay on the real page URL, not the shortener redirect

## Test plan
- [x] `npx tsc --noEmit`
- [x] PHP feature tests (`BioLinkShortLinkTest`, `ShortLinkTest`) pass, including new regression test for page/tab share URLs
- [x] `npm run build`
- [x] Live browser check on local dev server: whole-page and Products-tab Share sheets render correct distinct short links; canonical/og:url tags confirmed to still show the real page URL via DOM inspection

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE