### PR TITLE
Fix bio share icons hidden by ad-blocker cosmetic filters

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -217,19 +217,22 @@ function ShareSheet({
     </div>
   )
 
+  // Intent URLs are opened via `window.open` at click time rather than a
+  // static `href` — ad blockers' cosmetic filter lists (e.g. Fanboy's Social
+  // Blocking List) match and hide anchors whose `href` attribute contains
+  // known share-intent hosts like facebook.com/sharer or twitter.com/intent.
   const renderSocialShare = () => (
     <div className="mt-3 flex justify-center gap-2">
       {SOCIAL_SHARE.map(({ name, Icon, href }) => (
-        <a
+        <button
           key={name}
-          href={href(url, shareTitle)}
-          target="_blank"
-          rel="noopener noreferrer"
+          type="button"
+          onClick={() => window.open(href(url, shareTitle), '_blank', 'noopener,noreferrer')}
           aria-label={`Share on ${name}`}
           className="flex h-9 w-9 items-center justify-center rounded-full border border-[#e4d7c4] bg-white text-[#5b4a3a] transition hover:border-[#c98a4b] hover:text-[#b8541f]"
         >
           <Icon className="h-4 w-4" />
-        </a>
+        </button>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary
- Social share icons (X/Facebook/LinkedIn/WhatsApp/Reddit) in the bio page Share sheet were rendering with `display:none`, but only on the real domain, not localhost.
- Root cause: ad-blocker cosmetic filter lists (e.g. Fanboy's Social Blocking List) match anchors whose `href` contains known share-intent hosts like `facebook.com/sharer` or `twitter.com/intent`, and hide them. Confirmed by swapping an anchor's `href` to a neutral value in devtools — it un-hid immediately.
- Fix: build the share-intent URL at click time via `window.open` instead of a static `href`, so there's nothing for the filter to match against. Short-link behavior is unchanged (verified the opened URL still carries `/s/{code}`).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Verified locally: buttons render, stay visible, and `window.open` receives a share-intent URL wrapping the short link (`/s/{code}`)
- [ ] Smoke-test on `https://harun.dev/bio` after deploy

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved social sharing controls to work more reliably by avoiding ad blocker filtering.
  * Share links now open the intended social sharing windows when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->