### PR TITLE
Shorten blog share links and QR codes

### DIFF
--- a/app/Support/BlogRepository.php
+++ b/app/Support/BlogRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use App\Models\ShortLink;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use RuntimeException;
@@ -133,6 +134,7 @@ class BlogRepository
                 ->all(),
             'url' => $this->relativeUrl($post['slug']),
             'canonicalUrl' => $this->absoluteUrl($post['slug']),
+            'shareUrl' => $this->shareUrl($post),
             'sourceUrl' => $post['sourceUrl'] ?? $this->sourceUrl($post['slug']),
             'contentText' => $this->contentText($contentHtml),
         ];
@@ -158,6 +160,20 @@ class BlogRepository
     public function absoluteUrl(string $slug): string
     {
         return rtrim(config('app.url', url('/')), '/').$this->relativeUrl($slug);
+    }
+
+    /**
+     * @param  array<string, mixed>  $post
+     */
+    public function shareUrl(array $post): string
+    {
+        $absoluteUrl = $this->absoluteUrl($post['slug']);
+
+        return Cache::remember(
+            "post.shareurl.{$post['slug']}",
+            3600,
+            fn () => ShortLink::getOrCreateForUrl($absoluteUrl, $post['title'])?->short_url ?? $absoluteUrl,
+        );
     }
 
     public function sourceUrl(string $slug): string

--- a/resources/js/Pages/Blog/Index.tsx
+++ b/resources/js/Pages/Blog/Index.tsx
@@ -17,6 +17,7 @@ interface BlogPostSummary {
   tags: Array<{ name: string; slug: string }>
   url: string
   canonicalUrl: string
+  shareUrl: string
   sourceUrl: string
 }
 
@@ -185,7 +186,7 @@ export default function BlogIndex({ posts, canonicalUrl }: BlogIndexProps) {
                   </div>
 
                   <ShareButton
-                    url={post.canonicalUrl}
+                    url={post.shareUrl}
                     title={post.title}
                     shareTitle={post.title}
                     label={`Share "${post.title}"`}

--- a/resources/js/Pages/Blog/Post.tsx
+++ b/resources/js/Pages/Blog/Post.tsx
@@ -30,6 +30,7 @@ interface BlogPostSummary {
   tags: BlogPostTag[]
   url: string
   canonicalUrl: string
+  shareUrl: string
   sourceUrl: string
 }
 
@@ -309,7 +310,7 @@ export default function BlogPostPage({
                     {post.viewCount ?? 0} views
                   </span>
                   <ShareButton
-                    url={canonicalUrl}
+                    url={post.shareUrl}
                     title={post.title}
                     shareTitle={post.title}
                     label={`Share "${post.title}"`}

--- a/tests/Feature/BlogShareUrlTest.php
+++ b/tests/Feature/BlogShareUrlTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ShortLink;
+use App\Support\BlogRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BlogShareUrlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SLUG = 'production-ai-code-review-for-terraform-and-lambda-prs';
+
+    public function test_blog_index_exposes_a_shortened_share_url(): void
+    {
+        $blog = app(BlogRepository::class);
+        $post = $blog->find(self::SLUG);
+        $summary = $blog->summarizePost($post);
+
+        $this->assertMatchesRegularExpression('#^https?://[^/]+/s/[A-Za-z0-9]+$#', $summary['shareUrl']);
+        $this->assertSame($blog->absoluteUrl(self::SLUG), $summary['canonicalUrl']);
+    }
+
+    public function test_repeated_reads_reuse_the_same_short_link(): void
+    {
+        $blog = app(BlogRepository::class);
+        $post = $blog->find(self::SLUG);
+
+        $first = $blog->summarizePost($post)['shareUrl'];
+        $second = $blog->summarizePost($post)['shareUrl'];
+
+        $this->assertSame($first, $second);
+        $this->assertSame(1, ShortLink::count());
+    }
+
+    public function test_blog_post_route_returns_a_shortened_share_url(): void
+    {
+        $response = $this->get('/blog/'.self::SLUG);
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->where('post.canonicalUrl', app(BlogRepository::class)->absoluteUrl(self::SLUG))
+            ->has('post.shareUrl')
+            ->where('post.shareUrl', fn (string $shareUrl) => str_contains($shareUrl, '/s/'))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Blog Share sheets (post page and listing cards) used the raw `/blog/{slug}` URL; the QR code and copy link were unshortened.
- `BlogRepository::summarizePost()` now resolves a cached `shareUrl` via `ShortLink::getOrCreateForUrl()`, reusing the same short link across index/post/related renders (deduped by `url_hash`).
- `canonicalUrl` is untouched, still the raw `/blog/{slug}` URL used for `<link rel=canonical>`, `og:url`, and RSS.
- Both `Post.tsx` and `Index.tsx` Share buttons now pass `shareUrl` instead of `canonicalUrl`; `ShareSheet`/`ShareButton` needed no changes since they already build the QR/copy/social links from whatever `url` they're given.

## Test plan
- [x] `php artisan test --filter=BlogShareUrlTest` — 3 passed, 16 assertions
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] Verified via curl + tinker: index and post-page payloads for the same slug return the same `/s/{code}`, redirect resolves 302 to the post, and a click is recorded
- [x] Browser: opened the Share sheet on a local post page, confirmed the QR and Copy link render from the shortened URL

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shortened sharing links for blog posts.
  * Share buttons now use dedicated share URLs while preserving canonical URLs for page metadata.
  * Repeated requests reuse the same shortened link.

* **Tests**
  * Added coverage for shortened share links on blog listings and post pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->