### PR TITLE
Fix Share sheet clipping on blog post pages

### DIFF
--- a/resources/js/Pages/Blog/Post.tsx
+++ b/resources/js/Pages/Blog/Post.tsx
@@ -252,13 +252,13 @@ export default function BlogPostPage({
 
       <div className="pt-24">
           <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <article className="overflow-hidden rounded-[2rem] border border-slate-200 bg-white shadow-[0_30px_90px_-55px_rgba(15,23,42,0.45)]">
+            <article className="rounded-[2rem] border border-slate-200 bg-white shadow-[0_30px_90px_-55px_rgba(15,23,42,0.45)]">
               {coverImageUrl ? (
-                <div className="overflow-hidden border-b border-slate-200 bg-slate-100">
+                <div className="overflow-hidden rounded-t-[2rem] border-b border-slate-200 bg-slate-100">
                   <img src={coverImageUrl} alt={post.title} className="h-[clamp(16rem,42vw,30rem)] w-full object-cover object-top" />
                 </div>
               ) : (
-                <div className="border-b border-slate-200 bg-[linear-gradient(180deg,#0f172a_0%,#111827_100%)] px-6 py-14 text-white sm:px-10 sm:py-16 lg:px-14 lg:py-20">
+                <div className="rounded-t-[2rem] border-b border-slate-200 bg-[linear-gradient(180deg,#0f172a_0%,#111827_100%)] px-6 py-14 text-white sm:px-10 sm:py-16 lg:px-14 lg:py-20">
                   <div className="max-w-3xl space-y-5">
                     <p className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-white/90">
                       <BookOpen className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- The post header `<article>` had `overflow-hidden`, which clipped the (non-portaled) Share dropdown partway through the QR code.
- Reused the existing bio-page fix: drop `overflow-hidden` from the article, add `rounded-t-[2rem]` to its hero children so the corners still look clipped.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Verified in browser: Share dropdown on a post page now renders fully, no clipping

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE