### PR TITLE
Fix Share sheet overflowing off-screen on mobile

### DIFF
--- a/resources/js/Components/ShareButton.tsx
+++ b/resources/js/Components/ShareButton.tsx
@@ -11,7 +11,7 @@ export function ShareButton({
   label = 'Share',
   theme = 'warm',
   triggerClassName = '',
-  panelClassName = 'right-0',
+  panelClassName = 'sm:right-0',
   wrapperClassName = 'relative',
   children,
 }: {
@@ -57,7 +57,9 @@ export function ShareButton({
         {children ?? <Share2 className="h-4 w-4" />}
       </button>
       {open && (
-        <div className={`absolute top-full z-30 mt-2 ${panelClassName}`}>
+        <div
+          className={`fixed inset-x-4 bottom-4 z-30 sm:absolute sm:inset-x-auto sm:bottom-auto sm:top-full sm:mt-2 ${panelClassName}`}
+        >
           <ShareSheet title={title} url={url} shareTitle={shareTitle} theme={theme} onClose={() => setOpen(false)} />
         </div>
       )}

--- a/resources/js/Components/ShareSheet.tsx
+++ b/resources/js/Components/ShareSheet.tsx
@@ -125,7 +125,7 @@ export function ShareSheet({
   )
 
   return (
-    <div role="menu" className={`w-72 rounded-2xl border ${t.border} ${t.panelBg} p-4 text-left shadow-xl ${t.panelShadow}`}>
+    <div role="menu" className={`w-full rounded-2xl border ${t.border} ${t.panelBg} p-4 text-left shadow-xl sm:w-72 ${t.panelShadow}`}>
       <div className="flex items-center justify-between gap-2">
         <p className={`truncate ${t.font} text-xs font-semibold uppercase tracking-wider ${t.label}`}>{title}</p>
         <div className="flex shrink-0 items-center gap-0.5">


### PR DESCRIPTION
## Summary
- The Share panel was anchored via `right-0` relative to its trigger button. That works when the trigger sits near the right edge of its row, but on the post page's mobile metadata row the Share pill wraps onto its own line near the left, so the fixed-width panel overflowed off the left edge of the screen.
- Below the `sm` breakpoint, the panel now renders as a fixed, full-width bottom sheet (`fixed inset-x-4 bottom-4`) instead of a trigger-anchored dropdown, so it always stays fully on screen no matter where the trigger sits. Desktop behavior (dropdown under the trigger) is unchanged at `sm:` and up.
- Shared component (`ShareButton`/`ShareSheet`), so this also covers the blog listing cards and any future usage, not just the post page.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Verified in browser at a narrow (~600px) viewport: Share panel renders as a full-width bottom sheet, fully on screen, QR/social icons/actions all visible
- [x] Verified desktop dropdown behavior still unchanged

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved share menu positioning and responsiveness across mobile and desktop screen sizes.
  * Updated mobile share sheets to appear as bottom panels while retaining dropdown behavior on larger screens.
  * Made the share menu use the available width on smaller screens for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->