### PR TITLE
Fix Bio page overscrolling past content on iPhone

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -317,7 +317,7 @@ export default function Bio({
         <link rel="canonical" href={canonicalUrl} />
       </Head>
 
-      <main className="relative min-h-screen overflow-hidden bg-[#f7f1e8] px-4 py-10 text-[#2b2320] sm:px-6 sm:py-14 lg:px-8">
+      <main className="relative min-h-dvh overflow-hidden bg-[#f7f1e8] px-4 py-10 text-[#2b2320] sm:px-6 sm:py-14 lg:px-8">
         {/* Layered warm glow */}
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_50%_at_20%_-10%,rgba(217,157,89,0.35),transparent),radial-gradient(ellipse_55%_45%_at_100%_110%,rgba(184,84,31,0.22),transparent)]" />
         {/* Fine grain for depth over the flat fill */}
@@ -330,7 +330,7 @@ export default function Bio({
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: 'easeOut' }}
-          className="relative mx-auto flex min-h-[calc(100vh-6rem)] w-full max-w-xl flex-col items-center pt-12"
+          className="relative mx-auto flex min-h-[calc(100dvh-6rem)] w-full max-w-xl flex-col items-center pt-12"
         >
           {/* Whole-page share button */}
           <div className="absolute right-0 top-0" ref={openMenu === 'page' ? menuRef : null}>


### PR DESCRIPTION
## Summary
- iOS Safari's `100vh` is measured against the large viewport (toolbar retracted), so `min-h-screen` on the Bio page made the document taller than what's actually visible on load, letting visitors scroll past the footer into empty background.
- Swap both `vh`-based heights on `resources/js/Pages/Bio.tsx` for `dvh` (dynamic viewport height), which tracks the real visible viewport. Tailwind v4.3 supports it natively.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Verified locally at a 390x844 viewport: `main`'s computed `min-height` resolves to `100dvh` (matches `window.innerHeight`), content fills the screen with no gap, footer sits right after the last card
- [ ] Confirm on an actual iPhone after deploy that `/bio` no longer scrolls past the content

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE