### PR TITLE
Use svh instead of dvh for Bio page height

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -317,7 +317,7 @@ export default function Bio({
         <link rel="canonical" href={canonicalUrl} />
       </Head>
 
-      <main className="relative min-h-dvh overflow-hidden bg-[#f7f1e8] px-4 py-10 text-[#2b2320] sm:px-6 sm:py-14 lg:px-8">
+      <main className="relative min-h-svh overflow-hidden bg-[#f7f1e8] px-4 py-10 text-[#2b2320] sm:px-6 sm:py-14 lg:px-8">
         {/* Layered warm glow */}
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_50%_at_20%_-10%,rgba(217,157,89,0.35),transparent),radial-gradient(ellipse_55%_45%_at_100%_110%,rgba(184,84,31,0.22),transparent)]" />
         {/* Fine grain for depth over the flat fill */}
@@ -330,7 +330,7 @@ export default function Bio({
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: 'easeOut' }}
-          className="relative mx-auto flex min-h-[calc(100dvh-6rem)] w-full max-w-xl flex-col items-center pt-12"
+          className="relative mx-auto flex min-h-[calc(100svh-6rem)] w-full max-w-xl flex-col items-center pt-12"
         >
           {/* Whole-page share button */}
           <div className="absolute right-0 top-0" ref={openMenu === 'page' ? menuRef : null}>


### PR DESCRIPTION
## Summary
- PR #54 switched the Bio page from `vh` to `dvh` to fix scrolling past the content on iPhone, but a follow-up screenshot showed a new white gap below the footer on real hardware — `dvh` tracks Safari's toolbar in real time, and `min-height` doesn't reliably repaint when the toolbar auto-collapses mid-scroll, briefly exposing the white `body` background below `main`.
- Switch both `dvh` values to `svh` (small viewport height), which is pinned to the toolbar-expanded size. `main` is then never taller than what's guaranteed visible in any toolbar state, so there's nothing to recalculate mid-scroll.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Verified locally: `main`'s computed `min-height` resolves to `100svh` (matches `window.innerHeight`)
- [ ] Confirm on an actual iPhone after deploy that `/bio` has no gap below the footer at any point during scroll

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Bio page’s layout behavior on mobile devices, reducing unwanted resizing when browser controls appear or disappear.
  * Updated the page to maintain more consistent content height across viewport changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->