### PR TITLE
Fix white overscroll gap on mobile app-wide

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -114,6 +114,10 @@
   }
   html {
     overscroll-behavior-y: none;
+    /* Matches PublicLayout's bg-slate-50 — iOS Safari paints this color into
+       the overscroll/toolbar-collapse region, so it must match the page
+       instead of the default white body. */
+    background-color: #f8fafc;
   }
   body {
     @apply bg-background text-foreground;

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -262,6 +262,18 @@ export default function Bio({
     window.history.replaceState(null, '', newUrl)
   }, [activeSlug, tabGroups])
 
+  // Paint the root canvas cream to match this page. iOS Safari uses the
+  // <html> background to fill the overscroll/toolbar-collapse region, and the
+  // app default (set in app.css) is slate to match PublicLayout — without
+  // this override that region flashes slate instead of Bio's cream.
+  useEffect(() => {
+    const root = document.documentElement
+    root.style.backgroundColor = '#f7f1e8'
+    return () => {
+      root.style.backgroundColor = ''
+    }
+  }, [])
+
   const tabShareUrl = useCallback(
     (slug: string) => {
       if (tabShareUrls[slug]) return tabShareUrls[slug]


### PR DESCRIPTION
## Summary
- iOS Safari paints the overscroll/toolbar-collapse region using the root `<html>` background; with no background set there, the white `<body>` showed through on every page, not just Bio.
- `html` now defaults to `#f8fafc` (slate-50, matching `PublicLayout`'s wrapper) so the gap is invisible on every default page including the home page.
- Bio sets the root to its own cream `#f7f1e8` while mounted, and restores the default on unmount.
- Supersedes the earlier Bio-only `dvh`/`svh` attempts (PR #54, #55), which only changed `main`'s height and never touched the actual cause.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Local browser: `htmlBg` is `rgb(248,250,252)` on the home page and `rgb(247,241,232)` on `/bio`
- [ ] Confirm on iPhone after deploy: no white strip below the footer on either page

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE