### PR TITLE
Match root canvas color to the footer, not the page wrapper

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -114,10 +114,11 @@
   }
   html {
     overscroll-behavior-y: none;
-    /* Matches PublicLayout's bg-slate-50 — iOS Safari paints this color into
-       the overscroll/toolbar-collapse region, so it must match the page
-       instead of the default white body. */
-    background-color: #f8fafc;
+    /* Matches Footer's bg-slate-950 — iOS Safari paints this color into the
+       overscroll/toolbar-collapse region below the page, and every default
+       page (PublicLayout) ends with the dark Footer, not the slate-50 wrapper
+       behind it. */
+    background-color: #020617;
   }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
## Summary
- PR #56 set the root `<html>` background to slate-50 to fix the white overscroll gap on mobile, but the gap was still visible (light gray) in production.
- Root cause: every default page ends with the dark Footer (`bg-slate-950`), which sits on the true bottom edge of the document, not the slate-50 wrapper behind it. iOS Safari paints the exposed overscroll/toolbar-collapse region with whatever's at that edge.
- Change `html`'s background from `#f8fafc` (slate-50) to `#020617` (slate-950) so it matches the Footer.
- Bio's own cream override (from PR #56) is untouched, since Bio's own footer is transparent and inherits the cream `main` background all the way to the bottom.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Local: `getComputedStyle(document.documentElement).backgroundColor` now matches `getComputedStyle(document.querySelector('footer')).backgroundColor` (`rgb(2, 6, 23)`) on the home page
- [ ] Confirm on iPhone after deploy: no light gap below the footer

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the page background to a dark color that matches the footer.
  * Improved the appearance of overscroll and toolbar-collapse areas on iOS Safari.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->