### PR TITLE
Add product descriptions to bio page and enlarge profile picture

### DIFF
--- a/app/Http/Controllers/Admin/BioLinkController.php
+++ b/app/Http/Controllers/Admin/BioLinkController.php
@@ -238,6 +238,7 @@ class BioLinkController extends Controller
     {
         return $request->validate([
             'label' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:255'],
             'url' => ['required', 'string', 'max:2048'],
             'icon' => ['required', 'string', 'max:60'],
             'thumbnail' => ['nullable', 'image', 'max:2048'],
@@ -262,6 +263,7 @@ class BioLinkController extends Controller
         return [
             'id' => $link->id,
             'label' => $link->label,
+            'description' => $link->description,
             'url' => $link->url,
             'icon' => $link->icon,
             'thumbnail_url' => $link->thumbnail_url,

--- a/app/Models/BioLink.php
+++ b/app/Models/BioLink.php
@@ -13,6 +13,7 @@ class BioLink extends Model
 {
     protected $fillable = [
         'label',
+        'description',
         'url',
         'short_link_id',
         'tab',

--- a/database/migrations/2026_07_23_144706_add_description_to_bio_links_table.php
+++ b/database/migrations/2026_07_23_144706_add_description_to_bio_links_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('bio_links', function (Blueprint $table) {
+            $table->string('description')->nullable()->after('label');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bio_links', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/database/migrations/2026_07_23_144832_backfill_bio_link_product_descriptions.php
+++ b/database/migrations/2026_07_23_144832_backfill_bio_link_product_descriptions.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Models\BioLink;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Backfills `description` for the /bio "Products" tab links seeded in
+ * 2026_07_21_154845_seed_product_bio_links.php, reusing the taglines from
+ * resources/js/Pages/Products.tsx so both pages describe each product the
+ * same way. Keyed on `url`, same as the seed migration.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Data-seed migration, not schema: skip in the testing environment so
+        // it doesn't pollute the fresh `bio_links` table RefreshDatabase gives
+        // each test.
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        $descriptions = [
+            'https://toolblip.com' => 'Free online developer tools',
+            'https://ploy.cloud' => 'Managed hosting for Laravel, WordPress, PHP, and Node.js',
+            'https://crontinel.com' => 'Cron, queue, and background job monitoring',
+            'https://appnary.com' => 'Shopify apps for merchants',
+            'https://amazingplugins.com' => 'Free WooCommerce plugins',
+        ];
+
+        foreach ($descriptions as $url => $description) {
+            BioLink::where('url', $url)->update(['description' => $description]);
+        }
+    }
+
+    public function down(): void
+    {
+        BioLink::whereIn('url', [
+            'https://toolblip.com',
+            'https://ploy.cloud',
+            'https://crontinel.com',
+            'https://appnary.com',
+            'https://amazingplugins.com',
+        ])->update(['description' => null]);
+    }
+};

--- a/resources/js/Pages/Admin/Bio/Create.tsx
+++ b/resources/js/Pages/Admin/Bio/Create.tsx
@@ -5,6 +5,7 @@ import BioLinkForm, { type BioLinkFormData } from './Partials/BioLinkForm'
 export default function Create() {
   const { data, setData, post, processing, errors } = useForm<BioLinkFormData>({
     label: '',
+    description: '',
     url: '',
     icon: 'link',
     thumbnail: null,

--- a/resources/js/Pages/Admin/Bio/Edit.tsx
+++ b/resources/js/Pages/Admin/Bio/Edit.tsx
@@ -5,6 +5,7 @@ import BioLinkForm, { type BioLinkFormData } from './Partials/BioLinkForm'
 interface BioLinkRecord {
   id: number
   label: string
+  description: string | null
   url: string
   icon: string
   thumbnail_url: string | null
@@ -21,6 +22,7 @@ interface BioLinkRecord {
 export default function Edit({ link }: { link: BioLinkRecord }) {
   const { data, setData, processing, errors } = useForm<BioLinkFormData>({
     label: link.label,
+    description: link.description ?? '',
     url: link.url,
     icon: link.icon ?? 'link',
     thumbnail: null,

--- a/resources/js/Pages/Admin/Bio/Partials/BioLinkForm.tsx
+++ b/resources/js/Pages/Admin/Bio/Partials/BioLinkForm.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 export interface BioLinkFormData {
   label: string
+  description: string
   url: string
   icon: string
   thumbnail: File | null
@@ -97,6 +98,19 @@ export default function BioLinkForm({
           required
         />
         <InputError message={errors.label} className="mt-2" />
+      </div>
+
+      <div>
+        <InputLabel htmlFor="description" value="Description (optional)" />
+        <TextInput
+          id="description"
+          className="mt-1 block w-full"
+          value={data.description}
+          onChange={(e) => setData('description', e.target.value)}
+          placeholder="e.g. Free online developer tools"
+        />
+        <p className="mt-1 text-xs text-gray-500">Shown under the label on the public /bio page.</p>
+        <InputError message={errors.description} className="mt-2" />
       </div>
 
       <div>

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -9,6 +9,7 @@ import { ShareSheet } from '@/Components/ShareSheet'
 interface BioLink {
   id: number
   label: string
+  description: string | null
   url: string
   share_url: string
   icon: string
@@ -369,10 +370,10 @@ export default function Bio({
               <img
                 src={getImageUrl('/images/profile/harun-bio.jpg')}
                 alt="Harun R. Rayhan"
-                className="h-24 w-24 rounded-full border-4 border-[#fffaf6] object-cover shadow-lg shadow-[#2b2320]/10"
+                className="h-32 w-32 rounded-full border-4 border-[#fffaf6] object-cover shadow-lg shadow-[#2b2320]/10 sm:h-36 sm:w-36"
                 loading="eager"
-                width={96}
-                height={96}
+                width={144}
+                height={144}
               />
             </div>
 
@@ -560,11 +561,26 @@ export default function Bio({
                       >
                         <div className="relative flex-1 overflow-hidden rounded-l-2xl">
                           <LinkAnchor link={link} className="absolute inset-0" />
-                          <span className="pointer-events-none flex items-center justify-center gap-2.5 px-5 py-3.5">
+                          <span
+                            className={`pointer-events-none flex items-center gap-2.5 px-5 py-3.5 ${
+                              link.description ? '' : 'justify-center'
+                            }`}
+                          >
                             <LinkFavicon link={link} className="h-4 w-4 shrink-0 text-[#8a6a45]" />
-                            <span className="truncate font-mono text-sm font-medium text-[#2b2320]">
-                              {link.label}
-                            </span>
+                            {link.description ? (
+                              <span className="min-w-0 flex-1 text-left">
+                                <span className="block truncate font-mono text-sm font-medium text-[#2b2320]">
+                                  {link.label}
+                                </span>
+                                <span className="block truncate text-xs text-[#a3937e]">
+                                  {link.description}
+                                </span>
+                              </span>
+                            ) : (
+                              <span className="truncate font-mono text-sm font-medium text-[#2b2320]">
+                                {link.label}
+                              </span>
+                            )}
                           </span>
                         </div>
                         <ShareTrigger

--- a/routes/web.php
+++ b/routes/web.php
@@ -148,13 +148,14 @@ Route::get('/bio', function (Request $request, CountryResolver $countries) {
         ->active()
         ->orderBy('priority')
         ->orderBy('id')
-        ->get(['id', 'label', 'url', 'short_link_id', 'icon', 'thumbnail_path', 'featured', 'tab', 'tab_slug', 'include_countries', 'exclude_countries'])
+        ->get(['id', 'label', 'description', 'url', 'short_link_id', 'icon', 'thumbnail_path', 'featured', 'tab', 'tab_slug', 'include_countries', 'exclude_countries'])
         ->load('shortLink:id,code')
         ->filter(fn (BioLink $link) => $link->isVisibleInCountry($country))
         ->values()
         ->map(fn (BioLink $link) => [
             'id' => $link->id,
             'label' => $link->label,
+            'description' => $link->description,
             'url' => $link->url,
             'share_url' => $link->shortLink?->short_url ?? $link->url,
             'icon' => $link->icon,


### PR DESCRIPTION
## Summary
- Adds an optional `description` field to bio links, rendered under the label on the public /bio page (only when set, so tabs without descriptions look unchanged)
- Backfills descriptions for the 5 existing Products-tab links (Toolblip, PloyCloud, Crontinel, Appnary, Amazing Plugins), reusing the taglines already on the /products page
- Exposes the new field in the admin Bio link create/edit form
- Enlarges the bio page profile picture from 96px to 128px/144px

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] `php artisan test --filter=Bio` passes (27 tests)
- [x] Verified locally in browser: Products tab shows label + description per link, Links tab (no descriptions) renders unchanged, profile picture visibly larger

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional descriptions for bio links in the admin create and edit forms.
  - Displayed link descriptions beneath labels on bio pages when provided.
  - Improved profile image sizing and responsive presentation.

- **Bug Fixes**
  - Existing product links now include their predefined descriptions.
  - Link descriptions are preserved and displayed across admin and public views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->