### PR TITLE
Bigger product logos and accessibility fixes on the Bio page

### DIFF
--- a/database/migrations/2026_07_23_211557_backfill_bio_link_product_logos.php
+++ b/database/migrations/2026_07_23_211557_backfill_bio_link_product_logos.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\BioLink;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Copies the real product logos already shipped in public/images/products
+ * (used by resources/js/Pages/Products.tsx) onto the public storage disk and
+ * points each Products-tab bio link's existing `thumbnail_path` at its copy,
+ * so /bio can render the real logo instead of a generic favicon. Keyed on
+ * `url`, same as 2026_07_23_144832_backfill_bio_link_product_descriptions.php.
+ */
+return new class extends Migration
+{
+    /** @var array<string, string> url => filename in public/images/products */
+    private array $logos = [
+        'https://toolblip.com' => 'toolblip.svg',
+        'https://ploy.cloud' => 'ploycloud-icon.svg',
+        'https://crontinel.com' => 'crontinel.png',
+        'https://appnary.com' => 'appnary.svg',
+        'https://amazingplugins.com' => 'amazingplugins.jpg',
+    ];
+
+    public function up(): void
+    {
+        // Data-seed migration, not schema: skip in the testing environment so
+        // it doesn't pollute the fresh `bio_links` table RefreshDatabase gives
+        // each test.
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        foreach ($this->logos as $url => $filename) {
+            $source = public_path("images/products/{$filename}");
+            if (! is_file($source)) {
+                continue;
+            }
+
+            $path = "bio-thumbnails/{$filename}";
+            Storage::disk('public')->put($path, file_get_contents($source));
+
+            BioLink::where('url', $url)->update(['thumbnail_path' => $path]);
+        }
+    }
+
+    public function down(): void
+    {
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        foreach ($this->logos as $url => $filename) {
+            $path = "bio-thumbnails/{$filename}";
+            BioLink::where('url', $url)->where('thumbnail_path', $path)->update(['thumbnail_path' => null]);
+            Storage::disk('public')->delete($path);
+        }
+    }
+};

--- a/resources/js/Components/ShareSheet.tsx
+++ b/resources/js/Components/ShareSheet.tsx
@@ -27,6 +27,7 @@ const THEME = {
     qrHoverBorder: 'hover:border-[#c98a4b]',
     modalBackdrop: 'bg-[#2b2320]/80',
     qrFg: '#2b2320',
+    focusRing: 'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]',
   },
   slate: {
     font: '',
@@ -45,6 +46,7 @@ const THEME = {
     qrHoverBorder: 'hover:border-slate-400',
     modalBackdrop: 'bg-slate-950/80',
     qrFg: '#0f172a',
+    focusRing: 'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500',
   },
 } as const
 
@@ -88,7 +90,7 @@ export function ShareSheet({
         <button
           type="button"
           onClick={share}
-          className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg border ${t.border} bg-white px-3 py-2 ${t.font} text-xs font-medium ${t.action} transition ${t.actionHoverBg}`}
+          className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg border ${t.border} bg-white px-3 py-2 ${t.font} text-xs font-medium ${t.action} transition ${t.actionHoverBg} ${t.focusRing}`}
         >
           <Share2 className="h-3.5 w-3.5" /> Share
         </button>
@@ -96,7 +98,7 @@ export function ShareSheet({
       <button
         type="button"
         onClick={copy}
-        className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg border ${t.border} bg-white px-3 py-2 ${t.font} text-xs font-medium ${t.action} transition ${t.actionHoverBg}`}
+        className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg border ${t.border} bg-white px-3 py-2 ${t.font} text-xs font-medium ${t.action} transition ${t.actionHoverBg} ${t.focusRing}`}
       >
         {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
         {copied ? 'Copied' : 'Copy link'}
@@ -116,7 +118,7 @@ export function ShareSheet({
           type="button"
           onClick={() => window.open(href(url, shareTitle), '_blank', 'noopener,noreferrer')}
           aria-label={label ?? `Share on ${name}`}
-          className={`flex h-9 w-9 items-center justify-center rounded-full border ${t.border} bg-white ${t.social} transition ${t.socialHoverBorder} ${t.socialHoverText}`}
+          className={`flex h-9 w-9 items-center justify-center rounded-full border ${t.border} bg-white ${t.social} transition ${t.socialHoverBorder} ${t.socialHoverText} ${t.focusRing}`}
         >
           <Icon className="h-4 w-4" />
         </button>
@@ -133,7 +135,7 @@ export function ShareSheet({
             type="button"
             onClick={() => setExpanded(true)}
             aria-label="Expand"
-            className={`rounded-full p-1 ${t.muted} transition ${t.mutedHoverBg} ${t.mutedHoverText}`}
+            className={`rounded-full p-1 ${t.muted} transition ${t.mutedHoverBg} ${t.mutedHoverText} ${t.focusRing}`}
           >
             <Maximize2 className="h-3.5 w-3.5" />
           </button>
@@ -141,7 +143,7 @@ export function ShareSheet({
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className={`rounded-full p-1 ${t.muted} transition ${t.mutedHoverBg} ${t.mutedHoverText}`}
+            className={`rounded-full p-1 ${t.muted} transition ${t.mutedHoverBg} ${t.mutedHoverText} ${t.focusRing}`}
           >
             <X className="h-3.5 w-3.5" />
           </button>
@@ -152,7 +154,7 @@ export function ShareSheet({
         type="button"
         onClick={() => setExpanded(true)}
         aria-label="Enlarge QR code"
-        className={`mt-3 flex w-full justify-center rounded-xl border ${t.border} bg-white p-3 transition ${t.qrHoverBorder}`}
+        className={`mt-3 flex w-full justify-center rounded-xl border ${t.border} bg-white p-3 transition ${t.qrHoverBorder} ${t.focusRing}`}
       >
         <QRCodeSVG value={url} size={144} bgColor="#ffffff" fgColor={t.qrFg} level="M" />
       </button>
@@ -191,7 +193,7 @@ export function ShareSheet({
                       type="button"
                       onClick={() => setExpanded(false)}
                       aria-label="Collapse"
-                      className={`rounded-full p-1.5 ${t.muted} transition ${t.mutedHoverBg} ${t.mutedHoverText}`}
+                      className={`rounded-full p-1.5 ${t.muted} transition ${t.mutedHoverBg} ${t.mutedHoverText} ${t.focusRing}`}
                     >
                       <Minimize2 className="h-4 w-4" />
                     </button>
@@ -199,7 +201,7 @@ export function ShareSheet({
                       type="button"
                       onClick={onClose}
                       aria-label="Close"
-                      className={`rounded-full p-1.5 ${t.muted} transition ${t.mutedHoverBg} ${t.mutedHoverText}`}
+                      className={`rounded-full p-1.5 ${t.muted} transition ${t.mutedHoverBg} ${t.mutedHoverText} ${t.focusRing}`}
                     >
                       <X className="h-4 w-4" />
                     </button>

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -99,10 +99,13 @@ const itemVariants: Variants = {
 function LinkAnchor({ link, className }: { link: BioLink; className: string }) {
   const internal = isInternal(link.url)
   const mailish = isMailto(link.url)
+  // The card that hosts this anchor clips overflow, so a negative outline
+  // offset keeps the keyboard-focus ring visible instead of getting clipped.
+  const focusClassName = `${className} focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[#b8541f]`
 
   if (internal) {
     return (
-      <Link href={link.url} onClick={() => trackClick(link.id)} className={className} aria-label={link.label} />
+      <Link href={link.url} onClick={() => trackClick(link.id)} className={focusClassName} aria-label={link.label} />
     )
   }
 
@@ -112,7 +115,7 @@ function LinkAnchor({ link, className }: { link: BioLink; className: string }) {
       target={mailish ? undefined : '_blank'}
       rel={mailish ? undefined : 'noopener noreferrer'}
       onClick={() => trackClick(link.id)}
-      className={className}
+      className={focusClassName}
       aria-label={link.label}
     />
   )
@@ -128,6 +131,20 @@ function LinkFavicon({ link, className }: { link: BioLink; className: string }) 
   if (!favicon || failed) return <Icon className={className} />
 
   return <img src={favicon} alt="" className={`${className} rounded-[3px] object-contain`} onError={() => setFailed(true)} />
+}
+
+/** Standard-row icon: a link's real logo in a bordered box when it has a
+ *  thumbnail (Products), otherwise the small favicon/registry icon. */
+function LinkIcon({ link }: { link: BioLink }) {
+  if (link.thumbnail_url) {
+    return (
+      <span className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-[#e4d7c4] bg-white sm:h-12 sm:w-12">
+        <img src={link.thumbnail_url} alt="" className="h-7 w-7 object-contain sm:h-8 sm:w-8" />
+      </span>
+    )
+  }
+
+  return <LinkFavicon link={link} className="h-4 w-4 shrink-0 text-[#8a6a45]" />
 }
 
 /** The per-link share trigger (share icon button) plus its ShareSheet, self-contained. */
@@ -157,7 +174,7 @@ function ShareTrigger({
         aria-label={`Share ${link.label}`}
         aria-haspopup="menu"
         aria-expanded={isOpen}
-        className={`flex h-full w-11 shrink-0 items-center justify-center border-l border-[#e4d7c4]/70 text-[#8a6a45] transition hover:bg-[#f1e6d3] hover:text-[#2b2320] ${cornerClassName}`}
+        className={`flex h-full w-11 shrink-0 items-center justify-center border-l border-[#e4d7c4]/70 text-[#8a6a45] transition hover:bg-[#f1e6d3] hover:text-[#2b2320] focus-visible:bg-[#f1e6d3] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[#b8541f] ${cornerClassName}`}
       >
         <Share2 className="h-4 w-4" />
       </button>
@@ -353,7 +370,7 @@ export default function Bio({
               aria-label="Share this page"
               aria-haspopup="menu"
               aria-expanded={openMenu === 'page'}
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320]"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
             >
               <Share2 className="h-4 w-4" />
             </button>
@@ -406,12 +423,12 @@ export default function Bio({
                       rel="noopener noreferrer"
                       onClick={() => trackClick(link.id)}
                       aria-label={link.label}
-                      className="group relative flex h-14 w-14 shrink-0 items-center justify-center rounded-full text-[#4a3b2e] transition hover:-translate-y-0.5 hover:text-[#b8541f] sm:h-12 sm:w-12"
+                      className="group relative flex h-14 w-14 shrink-0 items-center justify-center rounded-full text-[#4a3b2e] transition hover:-translate-y-0.5 hover:text-[#b8541f] focus-visible:-translate-y-0.5 focus-visible:text-[#b8541f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f] sm:h-12 sm:w-12"
                     >
                       <Icon className="h-[26px] w-[26px] sm:h-[22px] sm:w-[22px]" />
                       <span
                         role="tooltip"
-                        className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md bg-[#2b2320] px-2 py-1 font-mono text-[10px] font-medium text-[#f7f1e8] opacity-0 shadow-md transition-opacity duration-150 [@media(hover:hover)]:group-hover:opacity-100"
+                        className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md bg-[#2b2320] px-2 py-1 font-mono text-[10px] font-medium text-[#f7f1e8] opacity-0 shadow-md transition-opacity duration-150 [@media(hover:hover)]:group-hover:opacity-100 group-focus-visible:opacity-100"
                       >
                         {link.label}
                       </span>
@@ -432,36 +449,40 @@ export default function Bio({
                     const isActive = group.slug === activeSlug
                     const shareId = `tab:${group.slug}` as const
                     return (
-                      <button
+                      <div
                         key={group.slug}
-                        type="button"
-                        onClick={() => setActiveSlug(group.slug)}
-                        className={`relative flex flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-full px-3.5 py-2 font-mono text-xs font-medium uppercase tracking-wider transition sm:text-[13px] ${
+                        className={`relative flex flex-1 items-center justify-center whitespace-nowrap rounded-full font-mono text-xs font-medium uppercase tracking-wider transition sm:text-[13px] ${
                           isActive
                             ? 'bg-[#2b2320] text-[#f7f1e8] shadow-sm'
                             : 'text-[#6b5d4f] hover:bg-[#f1e6d3] hover:text-[#2b2320]'
                         }`}
                       >
-                        {displayTab(group.label)}
-
-                        {/* Share button (visible on the active tab) */}
-                        <span
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            setOpenMenu(openMenu === shareId ? null : shareId)
-                          }}
-                          role="button"
-                          aria-label={`Share ${displayTab(group.label)}`}
-                          aria-haspopup="menu"
-                          aria-expanded={openMenu === shareId}
-                          className={`ml-0.5 inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded transition sm:h-4 sm:w-4 ${
-                            isActive ? 'opacity-70 hover:opacity-100' : 'hidden'
-                          }`}
-                          title={`Share ${displayTab(group.label)}`}
+                        <button
+                          type="button"
+                          onClick={() => setActiveSlug(group.slug)}
+                          aria-pressed={isActive}
+                          className="flex-1 rounded-full px-3.5 py-2 uppercase tracking-wider focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
                         >
-                          <Share2 className="h-3 w-3" />
-                        </span>
-                      </button>
+                          {displayTab(group.label)}
+                        </button>
+
+                        {/* Share button (visible on the active tab, a sibling
+                            of the select button so this isn't an interactive
+                            control nested inside another one). */}
+                        {isActive && (
+                          <button
+                            type="button"
+                            onClick={() => setOpenMenu(openMenu === shareId ? null : shareId)}
+                            aria-label={`Share ${displayTab(group.label)}`}
+                            aria-haspopup="menu"
+                            aria-expanded={openMenu === shareId}
+                            title={`Share ${displayTab(group.label)}`}
+                            className="mr-2 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-70 transition hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f] sm:h-4 sm:w-4"
+                          >
+                            <Share2 className="h-3 w-3" />
+                          </button>
+                        )}
+                      </div>
                     )
                   })}
                 </nav>
@@ -566,13 +587,13 @@ export default function Bio({
                               link.description ? '' : 'justify-center'
                             }`}
                           >
-                            <LinkFavicon link={link} className="h-4 w-4 shrink-0 text-[#8a6a45]" />
+                            <LinkIcon link={link} />
                             {link.description ? (
                               <span className="min-w-0 flex-1 text-left">
                                 <span className="block truncate font-mono text-sm font-medium text-[#2b2320]">
                                   {link.label}
                                 </span>
-                                <span className="block truncate text-xs text-[#a3937e]">
+                                <span className="block truncate text-xs text-[#6b5d4f]">
                                   {link.description}
                                 </span>
                               </span>
@@ -598,15 +619,15 @@ export default function Bio({
               </AnimatePresence>
 
               {currentLinks.length === 0 && (
-                <p className="rounded-2xl border border-dashed border-[#e4d7c4] px-4 py-6 text-center font-mono text-sm text-[#8a7a68]">
+                <p className="rounded-2xl border border-dashed border-[#e4d7c4] px-4 py-6 text-center font-mono text-sm text-[#6b5d4f]">
                   Coming soon.
                 </p>
               )}
             </nav>
           </div>
 
-          <footer className="mt-10 space-y-3 pb-6 text-center font-mono text-xs text-[#8a7a68]">
-            <p className="mx-auto max-w-xs text-[#a3937e]">
+          <footer className="mt-10 space-y-3 pb-6 text-center font-mono text-xs text-[#6b5d4f]">
+            <p className="mx-auto max-w-xs">
               Thanks for stopping by. New tools and posts land here first.
             </p>
             <p>


### PR DESCRIPTION
## Summary
- Products tab now renders real product logos (Toolblip, PloyCloud, Crontinel, Appnary, Amazing Plugins) in larger bordered icon boxes instead of generic favicons, backfilled via a data migration onto the existing `thumbnail_path` field.
- Fixed a nested-interactive-element bug in the tab share button (was `role="button"` inside a real `<button>`); restructured into sibling buttons with `aria-pressed` for tab state.
- Added visible `:focus-visible` keyboard focus rings across all interactive elements on the page (link cards, share buttons, tab buttons, social icons, page share button) and the shared `ShareSheet` component.
- Fixed two muted-text colors that failed WCAG AA contrast against their backgrounds.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Verified locally: Products tab shows all 5 real logos at the larger size
- [x] Verified AI Tools / Links tabs unaffected (still small favicons / empty states)
- [x] Verified tab share button opens the share sheet correctly, no console errors
- [x] Verified keyboard focus rings render (Tab through the page)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE