### PR TITLE
Redesign share sheet with colorful brand icon tiles

### DIFF
--- a/resources/js/Components/ShareSheet.tsx
+++ b/resources/js/Components/ShareSheet.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { QRCodeSVG } from 'qrcode.react'
-import { Check, Copy, Maximize2, Minimize2, Share2, X } from 'lucide-react'
+import { Check, Link2, Maximize2, Minimize2, Share, X } from 'lucide-react'
 import { SOCIAL_SHARE } from '@/lib/shareTargets'
 
 export type ShareSheetTheme = 'warm' | 'slate'
@@ -19,11 +19,6 @@ const THEME = {
     muted: 'text-[#8a6a45]',
     mutedHoverBg: 'hover:bg-[#f1e6d3]',
     mutedHoverText: 'hover:text-[#2b2320]',
-    action: 'text-[#3a2f27]',
-    actionHoverBg: 'hover:bg-[#f1e6d3]',
-    social: 'text-[#5b4a3a]',
-    socialHoverBorder: 'hover:border-[#c98a4b]',
-    socialHoverText: 'hover:text-[#b8541f]',
     qrHoverBorder: 'hover:border-[#c98a4b]',
     modalBackdrop: 'bg-[#2b2320]/80',
     qrFg: '#2b2320',
@@ -38,11 +33,6 @@ const THEME = {
     muted: 'text-slate-500',
     mutedHoverBg: 'hover:bg-slate-100',
     mutedHoverText: 'hover:text-slate-950',
-    action: 'text-slate-700',
-    actionHoverBg: 'hover:bg-slate-100',
-    social: 'text-slate-600',
-    socialHoverBorder: 'hover:border-slate-400',
-    socialHoverText: 'hover:text-slate-950',
     qrHoverBorder: 'hover:border-slate-400',
     modalBackdrop: 'bg-slate-950/80',
     qrFg: '#0f172a',
@@ -84,45 +74,52 @@ export function ShareSheet({
     navigator.share({ title: shareTitle, url }).catch(() => {})
   }
 
-  const renderActions = () => (
-    <div className="mt-3 flex gap-2">
-      {canShare && (
-        <button
-          type="button"
-          onClick={share}
-          className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg border ${t.border} bg-white px-3 py-2 ${t.font} text-xs font-medium ${t.action} transition ${t.actionHoverBg} ${t.focusRing}`}
-        >
-          <Share2 className="h-3.5 w-3.5" /> Share
-        </button>
-      )}
-      <button
-        type="button"
-        onClick={copy}
-        className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg border ${t.border} bg-white px-3 py-2 ${t.font} text-xs font-medium ${t.action} transition ${t.actionHoverBg} ${t.focusRing}`}
-      >
-        {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Copy className="h-3.5 w-3.5" />}
-        {copied ? 'Copied' : 'Copy link'}
-      </button>
-    </div>
-  )
-
   // Intent URLs are opened via `window.open` at click time rather than a
   // static `href` — ad blockers' cosmetic filter lists (e.g. Fanboy's Social
   // Blocking List) match and hide anchors whose `href` attribute contains
   // known share-intent hosts like facebook.com/sharer or twitter.com/intent.
+  // Copy-link and native-share ("More") are folded in as the first/last
+  // tiles so the whole row acts like a native OS share sheet.
   const renderSocialShare = () => (
-    <div className="mt-3 flex gap-2 overflow-x-auto py-1">
-      {SOCIAL_SHARE.map(({ name, label, Icon, href }) => (
+    <div className="mt-3 flex gap-3 overflow-x-auto py-1">
+      <button
+        type="button"
+        onClick={copy}
+        className={`flex w-16 shrink-0 flex-col items-center gap-1.5 rounded-xl py-1 ${t.focusRing}`}
+      >
+        <span className="flex h-14 w-14 items-center justify-center rounded-full bg-slate-100 text-slate-700">
+          {copied ? <Check className="h-5 w-5 text-emerald-600" /> : <Link2 className="h-5 w-5" />}
+        </span>
+        <span className={`${t.font} text-[11px] font-medium ${t.muted}`}>{copied ? 'Copied' : 'Copy link'}</span>
+      </button>
+
+      {SOCIAL_SHARE.map(({ name, label, Icon, href, bg, fg }) => (
         <button
           key={name}
           type="button"
           onClick={() => window.open(href(url, shareTitle), '_blank', 'noopener,noreferrer')}
           aria-label={label ?? `Share on ${name}`}
-          className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full border ${t.border} bg-white ${t.social} transition ${t.socialHoverBorder} ${t.socialHoverText} ${t.focusRing}`}
+          className={`flex w-16 shrink-0 flex-col items-center gap-1.5 rounded-xl py-1 ${t.focusRing}`}
         >
-          <Icon className="h-4 w-4" />
+          <span className="flex h-14 w-14 items-center justify-center rounded-full" style={{ background: bg, color: fg }}>
+            <Icon className="h-6 w-6" />
+          </span>
+          <span className={`${t.font} text-[11px] font-medium ${t.muted}`}>{name}</span>
         </button>
       ))}
+
+      {canShare && (
+        <button
+          type="button"
+          onClick={share}
+          className={`flex w-16 shrink-0 flex-col items-center gap-1.5 rounded-xl py-1 ${t.focusRing}`}
+        >
+          <span className="flex h-14 w-14 items-center justify-center rounded-full bg-slate-100 text-slate-700">
+            <Share className="h-5 w-5" />
+          </span>
+          <span className={`${t.font} text-[11px] font-medium ${t.muted}`}>More</span>
+        </button>
+      )}
     </div>
   )
 
@@ -160,7 +157,6 @@ export function ShareSheet({
       </button>
 
       {renderSocialShare()}
-      {renderActions()}
 
       {expanded &&
         typeof document !== 'undefined' &&
@@ -220,7 +216,6 @@ export function ShareSheet({
                 </div>
 
                 {renderSocialShare()}
-                {renderActions()}
               </motion.div>
             </motion.div>
           </AnimatePresence>,

--- a/resources/js/lib/shareTargets.ts
+++ b/resources/js/lib/shareTargets.ts
@@ -1,12 +1,16 @@
 import { Facebook, Linkedin, Mail, Messenger, Snapchat, Twitter, WhatsApp } from '@/lib/icons'
 
-// One-tap social-share targets shown in every ShareSheet, under the QR and
-// above Share/Copy. `href` builds each platform's share-intent URL.
+// One-tap social-share targets shown in every ShareSheet, under the QR.
+// `href` builds each platform's share-intent URL. `bg`/`fg` are the brand
+// tile colors for the icon circle (a CSS `background` value, so gradients
+// like Messenger's work too).
 export const SOCIAL_SHARE = [
   {
     name: 'X',
     label: undefined as string | undefined,
     Icon: Twitter,
+    bg: '#000000',
+    fg: '#ffffff',
     href: (url: string, title: string) =>
       `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`,
   },
@@ -17,18 +21,24 @@ export const SOCIAL_SHARE = [
     // visible without changing what it does.
     label: 'Share to Facebook' as string | undefined,
     Icon: Facebook,
+    bg: '#1877F2',
+    fg: '#ffffff',
     href: (url: string) => `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
   },
   {
     name: 'WhatsApp',
     label: undefined as string | undefined,
     Icon: WhatsApp,
+    bg: '#25D366',
+    fg: '#ffffff',
     href: (url: string, title: string) => `https://wa.me/?text=${encodeURIComponent(`${title} ${url}`)}`,
   },
   {
     name: 'LinkedIn',
     label: undefined as string | undefined,
     Icon: Linkedin,
+    bg: '#0A66C2',
+    fg: '#ffffff',
     href: (url: string) => `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
   },
   {
@@ -39,18 +49,24 @@ export const SOCIAL_SHARE = [
     // on desktop rather than a broken share dialog.
     label: undefined as string | undefined,
     Icon: Messenger,
+    bg: 'linear-gradient(135deg, #00B2FF 0%, #A033FF 50%, #FF5271 100%)',
+    fg: '#ffffff',
     href: (url: string) => `fb-messenger://share/?link=${encodeURIComponent(url)}`,
   },
   {
     name: 'Snapchat',
     label: undefined as string | undefined,
     Icon: Snapchat,
+    bg: '#FFFC00',
+    fg: '#ffffff',
     href: (url: string) => `https://www.snapchat.com/share?link=${encodeURIComponent(url)}`,
   },
   {
     name: 'Email',
     label: undefined as string | undefined,
     Icon: Mail,
+    bg: '#4B5563',
+    fg: '#ffffff',
     href: (url: string, title: string) =>
       `mailto:?subject=${encodeURIComponent(title)}&body=${encodeURIComponent(url)}`,
   },


### PR DESCRIPTION
## Summary
- Replace monotone `currentColor` icons with colorful brand-colored circular tiles + text labels, matching a native mobile share sheet
- Fold "Copy link" and "More" (native `navigator.share()`) into the scrollable icon row as the first/last tiles, replacing the separate Share/Copy Link buttons

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Verified locally on `/bio`: all 7 platform tiles render correct brand colors + labels, Copy link toggles to checkmark, Messenger gradient renders, More tile opens native share
- [x] Verified expanded QR modal view (same row, wider panel)
- [x] Verified a second usage site (`/blog` post card) renders identically, confirming the redesign propagates app-wide

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE