### PR TITLE
Shrink share sheet tiles, rename kicker to "Share link"

### DIFF
--- a/resources/js/Components/ShareSheet.tsx
+++ b/resources/js/Components/ShareSheet.tsx
@@ -47,7 +47,7 @@ const THEME = {
  *  Close dismisses the sheet everywhere. */
 export function ShareSheet({
   title,
-  kicker = 'Share this page',
+  kicker = 'Share link',
   url,
   shareTitle,
   onClose,
@@ -83,18 +83,18 @@ export function ShareSheet({
   // Copy-link and native-share ("More") are folded in as the first/last
   // tiles so the whole row acts like a native OS share sheet.
   //
-  // Tile size is smaller in the inline dropdown (mobile-first, grows at sm:)
-  // and stays at the dropdown's largest size in the expanded pop-up, which
-  // has room to spare at `max-w-md`.
+  // Tile size stays compact in the inline dropdown (mobile-first, grows a
+  // little at sm:) so more tiles fit without scrolling, and is fixed larger
+  // in the expanded pop-up, which has room to spare at `max-w-md`.
   const TILE = {
-    sheet: { wrap: 'w-14 sm:w-16', circle: 'h-11 w-11 sm:h-14 sm:w-14', icon: 'h-4 w-4 sm:h-6 sm:w-6', iconSm: 'h-4 w-4 sm:h-5 sm:w-5', label: 'text-[10px] sm:text-[11px]' },
-    modal: { wrap: 'w-16', circle: 'h-14 w-14', icon: 'h-6 w-6', iconSm: 'h-5 w-5', label: 'text-[11px]' },
+    sheet: { wrap: 'w-12 sm:w-14', circle: 'h-8 w-8 sm:h-11 sm:w-11', icon: 'h-3 w-3 sm:h-5 sm:w-5', iconSm: 'h-3 w-3 sm:h-4 sm:w-4', label: 'text-[9px] sm:text-[10px]', gap: 'gap-2' },
+    modal: { wrap: 'w-16', circle: 'h-14 w-14', icon: 'h-6 w-6', iconSm: 'h-5 w-5', label: 'text-[11px]', gap: 'gap-3' },
   } as const
 
   const renderSocialShare = (variant: keyof typeof TILE) => {
     const s = TILE[variant]
     return (
-      <div className="mt-3 flex gap-3 overflow-x-auto py-1">
+      <div className={`mt-3 flex ${s.gap} overflow-x-auto py-1`}>
         <button
           type="button"
           onClick={copy}

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -192,7 +192,7 @@ function ShareTrigger({
       </button>
       {isOpen && (
         <div className="absolute right-0 top-full z-30 mt-2">
-          <ShareSheet kicker="Share link" title={link.label} url={link.share_url} shareTitle={link.label} onClose={onClose} />
+          <ShareSheet title={link.label} url={link.share_url} shareTitle={link.label} onClose={onClose} />
         </div>
       )}
     </div>
@@ -212,7 +212,7 @@ export default function Bio({
   // Real page URL — feeds SEO tags (og:url, canonical). Must stay the actual
   // page, never the shortener redirect.
   const canonicalUrl = typeof window !== 'undefined' ? window.location.href : 'https://harun.dev/bio'
-  // Shortened page URL for the "Share this page" sheet's QR/copy/social links.
+  // Shortened page URL for the "Share link" sheet's QR/copy/social links.
   const pageShareLinkUrl = pageShareUrl ?? canonicalUrl
   // og:image/twitter:image need a fully-qualified URL. getImageUrl() already
   // returns an absolute CDN URL in production; fall back to the canonical


### PR DESCRIPTION
## Summary
- Shrinks the inline dropdown's share-tile icons ~20-27% (circles 44/56px → 32/44px) and tightens tile spacing so more fit per row without scrolling; the expanded pop-up modal keeps its original tile size unchanged.
- Renames the default kicker label from "Share this page" to "Share link" across all `ShareSheet` call sites, since most triggers (per-link, per-tab) point at a specific link rather than the whole page.

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] Verified on local dev at a 606px viewport: inline tiles render at 32px circles, panel stays fully on-screen, kicker shows "SHARE LINK"
- [x] Verified expanded pop-up modal tiles unchanged at ~56px circles

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated share prompts to use the clearer “Share link” wording.
  * Refined share tile sizing, spacing, icon dimensions, and label styling across inline and expanded views.
  * Improved spacing between inline sharing options for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->