### PR TITLE
Fix bio link cards overflowing on narrow viewports

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -417,7 +417,7 @@ export default function Bio({
                 Software Engineer turning Entrepreneur
               </p>
               <p className="font-mono text-xs text-[#6b5d4f] sm:text-sm">
-                DevOps · AI/ML · AWS · CloudOps · Infrastructure Automation
+                DevOps · AI / ML · AWS · CloudOps · Infrastructure Automation
               </p>
             </div>
 
@@ -533,7 +533,7 @@ export default function Bio({
             )}
 
             {/* Link cards for the active tab */}
-            <nav aria-label={`${displayTab(activeGroup?.label ?? 'Links')} links`} className="mt-6 grid w-full gap-3">
+            <nav aria-label={`${displayTab(activeGroup?.label ?? 'Links')} links`} className="mt-6 grid w-full grid-cols-1 gap-3">
               <AnimatePresence mode="wait">
                 <motion.div
                   key={activeSlug}
@@ -541,7 +541,7 @@ export default function Bio({
                   initial="hidden"
                   animate="show"
                   exit={{ opacity: 0, y: -8, transition: { duration: 0.15 } }}
-                  className="grid w-full gap-3"
+                  className="grid w-full grid-cols-1 gap-3"
                 >
                   {featuredLinks.map((link) => {
                     return (


### PR DESCRIPTION
## Summary
- Fixes bio page link cards spilling past the content edge on iPhone Safari (unconstrained CSS grid `auto` track sized to min-content instead of the container width)
- Changes "AI/ML" to "AI / ML" in the bio subtitle line

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Verified live at a simulated 360px width: grid track clamps to container width, zero overflowing cards, share button and right gutter fully visible, long descriptions truncate with an ellipsis

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE