### PR TITLE
Add email subscription with idle-triggered popup

### DIFF
--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\SubscribeRequest;
+use App\Models\Subscriber;
+
+class NewsletterController extends Controller
+{
+    public function subscribe(SubscribeRequest $request)
+    {
+        try {
+            Subscriber::firstOrCreate(
+                ['email' => $request->email],
+                [
+                    'source' => $request->source,
+                    'referrer' => $request->referrer,
+                    'status' => 'subscribed',
+                ]
+            );
+
+            return redirect()->back()->with('flash', [
+                'type' => 'success',
+                'message' => "You're subscribed. New tools and posts will land in your inbox.",
+            ]);
+        } catch (\Exception $e) {
+            report($e);
+
+            return redirect()->back()->with('flash', [
+                'type' => 'error',
+                'message' => 'Sorry, something went wrong. Please try again later.',
+            ]);
+        }
+    }
+}

--- a/app/Http/Requests/SubscribeRequest.php
+++ b/app/Http/Requests/SubscribeRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SubscribeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email', 'max:255'],
+            'source' => ['nullable', 'string', 'max:255'],
+            'referrer' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'email.required' => 'Please enter your email address.',
+            'email.email' => 'Please enter a valid email address.',
+        ];
+    }
+}

--- a/app/Models/Subscriber.php
+++ b/app/Models/Subscriber.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Subscriber extends Model
+{
+    protected $fillable = [
+        'email',
+        'source',
+        'referrer',
+        'status',
+    ];
+}

--- a/database/migrations/2026_07_24_060000_create_subscribers_table.php
+++ b/database/migrations/2026_07_24_060000_create_subscribers_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscribers', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+            $table->string('source')->nullable();
+            $table->string('referrer')->nullable();
+            $table->string('status')->default('subscribed');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subscribers');
+    }
+};

--- a/resources/js/Components/SubscribeButton.tsx
+++ b/resources/js/Components/SubscribeButton.tsx
@@ -1,0 +1,26 @@
+import { Mail } from 'lucide-react'
+import { Button } from '@/Components/ui/button'
+import { cn } from '@/lib/utils'
+import { useSubscribePopup } from '@/Components/SubscribeProvider'
+import { SubscribeTheme } from '@/Components/SubscribeForm'
+
+export function SubscribeButton({
+  source,
+  theme = 'slate',
+  label = 'Subscribe',
+  className,
+}: {
+  source: string
+  theme?: SubscribeTheme
+  label?: string
+  className?: string
+}) {
+  const { openPopup } = useSubscribePopup()
+
+  return (
+    <Button type="button" onClick={() => openPopup(source, theme)} className={cn('gap-2', className)}>
+      <Mail className="h-4 w-4" />
+      {label}
+    </Button>
+  )
+}

--- a/resources/js/Components/SubscribeForm.tsx
+++ b/resources/js/Components/SubscribeForm.tsx
@@ -1,0 +1,82 @@
+import { useState, FormEvent } from 'react'
+import { router } from '@inertiajs/react'
+import { toast } from 'sonner'
+import { Input } from '@/Components/ui/input'
+import { Button } from '@/Components/ui/button'
+import { cn } from '@/lib/utils'
+
+export type SubscribeTheme = 'warm' | 'slate'
+
+const THEME = {
+  warm: {
+    input: 'bg-white border-[#e4d7c4] focus-visible:ring-[#b8541f] text-[#2b2320] placeholder:text-[#8a6a45]',
+    button: 'bg-[#b8541f] hover:bg-[#9c4419] text-white',
+    error: 'text-[#b8541f]',
+  },
+  slate: {
+    input: 'bg-white border-slate-200 focus-visible:ring-slate-500 text-slate-950 placeholder:text-slate-400',
+    button: 'bg-slate-900 hover:bg-slate-800 text-white',
+    error: 'text-red-600',
+  },
+} as const
+
+export function SubscribeForm({
+  source,
+  theme = 'slate',
+  onSuccess,
+  className,
+}: {
+  source: string
+  theme?: SubscribeTheme
+  onSuccess?: () => void
+  className?: string
+}) {
+  const t = THEME[theme]
+  const [email, setEmail] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    setError('')
+
+    router.post(
+      '/subscribe',
+      { email, source, referrer: document.referrer || null },
+      {
+        preserveScroll: true,
+        onSuccess: () => {
+          setIsSubmitting(false)
+          setEmail('')
+          toast.success("You're subscribed. New tools and posts will land in your inbox.")
+          onSuccess?.()
+        },
+        onError: (errors: Record<string, string>) => {
+          setIsSubmitting(false)
+          setError(errors.email ?? 'Something went wrong. Please try again.')
+          toast.error(errors.email ?? 'Something went wrong. Please try again.')
+        },
+      },
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={cn('flex flex-col gap-2', className)}>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          required
+          className={cn('h-11', t.input)}
+        />
+        <Button type="submit" disabled={isSubmitting} className={cn('h-11 shrink-0 px-5', t.button)}>
+          {isSubmitting ? 'Subscribing…' : 'Subscribe'}
+        </Button>
+      </div>
+      {error && <p className={cn('text-sm', t.error)}>{error}</p>}
+    </form>
+  )
+}

--- a/resources/js/Components/SubscribePopup.tsx
+++ b/resources/js/Components/SubscribePopup.tsx
@@ -1,0 +1,88 @@
+import { createPortal } from 'react-dom'
+import { motion, AnimatePresence } from 'framer-motion'
+import { X, Mail } from 'lucide-react'
+import { SubscribeForm, SubscribeTheme } from '@/Components/SubscribeForm'
+
+const THEME = {
+  warm: {
+    backdrop: 'bg-[#2b2320]/80',
+    panel: 'bg-[#fffaf6]',
+    border: 'border-[#e4d7c4]',
+    title: 'text-[#2b2320]',
+    muted: 'text-[#8a6a45]',
+    iconBg: 'bg-[#f1e6d3] text-[#b8541f]',
+    close: 'text-[#8a6a45] hover:bg-[#f1e6d3] hover:text-[#2b2320]',
+  },
+  slate: {
+    backdrop: 'bg-slate-950/80',
+    panel: 'bg-white',
+    border: 'border-slate-200',
+    title: 'text-slate-950',
+    muted: 'text-slate-500',
+    iconBg: 'bg-slate-100 text-slate-700',
+    close: 'text-slate-500 hover:bg-slate-100 hover:text-slate-950',
+  },
+} as const
+
+export function SubscribePopup({
+  open,
+  onClose,
+  source,
+  theme = 'slate',
+}: {
+  open: boolean
+  onClose: () => void
+  source: string
+  theme?: SubscribeTheme
+}) {
+  if (typeof document === 'undefined') return null
+  const t = THEME[theme]
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Subscribe"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+          className={`fixed inset-0 z-[100] flex items-center justify-center ${t.backdrop} p-6 backdrop-blur-sm`}
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.96, y: 8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 8 }}
+            transition={{ duration: 0.18, ease: 'easeOut' }}
+            className={`relative w-full max-w-sm rounded-2xl border ${t.border} ${t.panel} p-6 shadow-2xl`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className={`absolute right-3 top-3 rounded-full p-1.5 transition ${t.close}`}
+            >
+              <X className="h-4 w-4" />
+            </button>
+
+            <span className={`flex h-10 w-10 items-center justify-center rounded-full ${t.iconBg}`}>
+              <Mail className="h-5 w-5" />
+            </span>
+
+            <h2 className={`mt-4 text-lg font-semibold ${t.title}`}>Get new posts and tools first</h2>
+            <p className={`mt-1 text-sm ${t.muted}`}>
+              I send an email when there's something worth reading. No spam, unsubscribe anytime.
+            </p>
+
+            <SubscribeForm source={source} theme={theme} onSuccess={onClose} className="mt-4" />
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  )
+}

--- a/resources/js/Components/SubscribeProvider.tsx
+++ b/resources/js/Components/SubscribeProvider.tsx
@@ -1,0 +1,49 @@
+import { createContext, useCallback, useContext, useState, ReactNode } from 'react'
+import { Toaster } from 'sonner'
+import { SubscribePopup } from '@/Components/SubscribePopup'
+import { SubscribeTheme } from '@/Components/SubscribeForm'
+import { useIdleSubscribe } from '@/hooks/useIdleSubscribe'
+
+const IDLE_MS = 60_000
+const DISMISS_KEY = 'subscribe-popup-dismissed'
+
+type SubscribeContextValue = {
+  openPopup: (source: string, theme?: SubscribeTheme) => void
+}
+
+const SubscribeContext = createContext<SubscribeContextValue | null>(null)
+
+export function useSubscribePopup() {
+  const ctx = useContext(SubscribeContext)
+  if (!ctx) throw new Error('useSubscribePopup must be used within a SubscribeProvider')
+  return ctx
+}
+
+/** Mounted once around the whole app (see app.tsx) so the idle popup and the
+ *  toast host cover every page, including Bio, which renders its own layout. */
+export function SubscribeProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false)
+  const [source, setSource] = useState('idle-popup')
+  const [theme, setTheme] = useState<SubscribeTheme>('slate')
+
+  const openPopup = useCallback((nextSource: string, nextTheme: SubscribeTheme = 'slate') => {
+    setSource(nextSource)
+    setTheme(nextTheme)
+    setOpen(true)
+  }, [])
+
+  const closePopup = useCallback(() => {
+    setOpen(false)
+    sessionStorage.setItem(DISMISS_KEY, '1')
+  }, [])
+
+  useIdleSubscribe(() => openPopup('idle-popup'), IDLE_MS, DISMISS_KEY)
+
+  return (
+    <SubscribeContext.Provider value={{ openPopup }}>
+      {children}
+      <Toaster position="top-right" richColors />
+      <SubscribePopup open={open} onClose={closePopup} source={source} theme={theme} />
+    </SubscribeContext.Provider>
+  )
+}

--- a/resources/js/Pages/Contact.tsx
+++ b/resources/js/Pages/Contact.tsx
@@ -12,7 +12,6 @@ import type React from "react"
 import {Head} from "@inertiajs/react";
 import {router} from '@inertiajs/react'
 import {toast} from "sonner"
-import { Toaster } from "sonner"
 import { usePage } from '@inertiajs/react'
 import { PageProps as InertiaPageProps } from '@inertiajs/core'
 import confetti from 'canvas-confetti';
@@ -171,7 +170,6 @@ export default function Contact() {
 
     return (
         <>
-            <Toaster position="top-right" richColors />
             <Head>
                 <title>Contact Harun | Cloud & DevOps Consulting Services</title>
                 <meta name="description" content="Get in touch for expert cloud computing and DevOps consulting services. Let's discuss your project needs in AWS, infrastructure automation, CI/CD, or any other cloud services." />

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -4,6 +4,7 @@ import './bootstrap';
 import { createInertiaApp, type ResolvedComponent } from '@inertiajs/react';
 import { createRoot } from 'react-dom/client';
 import PublicLayout from './Layouts/PublicLayout';
+import { SubscribeProvider } from './Components/SubscribeProvider';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 const pages = import.meta.glob('./Pages/**/*.tsx') as Record<
@@ -26,7 +27,11 @@ createInertiaApp({
     setup({ el, App, props }) {
         const root = createRoot(el);
 
-        root.render(<App {...props} />);
+        root.render(
+            <SubscribeProvider>
+                <App {...props} />
+            </SubscribeProvider>
+        );
     },
     progress: {
         color: '#4B5563',

--- a/resources/js/hooks/useIdleSubscribe.ts
+++ b/resources/js/hooks/useIdleSubscribe.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+
+const ACTIVITY_EVENTS = ['mousemove', 'keydown', 'scroll', 'touchstart'] as const
+
+/** Fires `onIdle` after `idleMs` of no mouse/keyboard/scroll/touch activity.
+ *  Skips entirely once `sessionStorage[dismissKey]` is set, so a dismissed
+ *  or subscribed visitor doesn't get retimed on the next page nav. */
+export function useIdleSubscribe(onIdle: () => void, idleMs: number, dismissKey: string) {
+  const onIdleRef = useRef(onIdle)
+  onIdleRef.current = onIdle
+
+  useEffect(() => {
+    if (sessionStorage.getItem(dismissKey)) return
+
+    let timer: ReturnType<typeof setTimeout>
+
+    const reset = () => {
+      if (sessionStorage.getItem(dismissKey)) return
+      clearTimeout(timer)
+      timer = setTimeout(() => {
+        if (sessionStorage.getItem(dismissKey)) return
+        onIdleRef.current()
+      }, idleMs)
+    }
+
+    reset()
+    ACTIVITY_EVENTS.forEach((event) => window.addEventListener(event, reset, { passive: true }))
+
+    return () => {
+      clearTimeout(timer)
+      ACTIVITY_EVENTS.forEach((event) => window.removeEventListener(event, reset))
+    }
+  }, [idleMs, dismissKey])
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ContactController;
+use App\Http\Controllers\NewsletterController;
 use App\Http\Controllers\BlogCommentController;
 use App\Http\Controllers\Admin\BioLinkController;
 use App\Http\Controllers\Admin\ShortLinkController;
@@ -278,6 +279,8 @@ Route::get('/contact', function () {
 })->name('contact');
 
 Route::post('/contact', [ContactController::class, 'submit'])->name('contact.submit');
+
+Route::post('/subscribe', [NewsletterController::class, 'subscribe'])->name('subscribe');
 
 Route::get('/case-studies', function (Request $request) {
     if ($request->getRequestUri() === '/case-studies/') {

--- a/tests/Feature/SubscriberTest.php
+++ b/tests/Feature/SubscriberTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Subscriber;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SubscriberTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_can_subscribe_with_a_valid_email()
+    {
+        $response = $this->post('/subscribe', [
+            'email' => 'jane@example.com',
+            'source' => 'bio',
+            'referrer' => 'direct',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('flash.type', 'success');
+
+        $this->assertDatabaseHas('subscribers', [
+            'email' => 'jane@example.com',
+            'source' => 'bio',
+            'referrer' => 'direct',
+            'status' => 'subscribed',
+        ]);
+    }
+
+    #[Test]
+    public function it_validates_required_email()
+    {
+        $response = $this->post('/subscribe', []);
+
+        $response->assertSessionHasErrors(['email']);
+        $this->assertDatabaseCount('subscribers', 0);
+    }
+
+    #[Test]
+    public function it_validates_email_format()
+    {
+        $response = $this->post('/subscribe', ['email' => 'not-an-email']);
+
+        $response->assertSessionHasErrors(['email']);
+        $this->assertDatabaseCount('subscribers', 0);
+    }
+
+    #[Test]
+    public function it_is_idempotent_for_a_repeat_email()
+    {
+        Subscriber::create([
+            'email' => 'jane@example.com',
+            'source' => 'homepage',
+            'status' => 'subscribed',
+        ]);
+
+        $response = $this->post('/subscribe', [
+            'email' => 'jane@example.com',
+            'source' => 'bio',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('flash.type', 'success');
+        $this->assertDatabaseCount('subscribers', 1);
+
+        // The original row wins; a repeat submission doesn't overwrite its source.
+        $this->assertDatabaseHas('subscribers', [
+            'email' => 'jane@example.com',
+            'source' => 'homepage',
+        ]);
+    }
+
+    #[Test]
+    public function it_allows_a_subscription_with_no_source_or_referrer()
+    {
+        $response = $this->post('/subscribe', ['email' => 'jane@example.com']);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('subscribers', [
+            'email' => 'jane@example.com',
+            'source' => null,
+            'referrer' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- New local `subscribers` table + `Subscriber` model, capturing email/source/referrer with idempotent `firstOrCreate` (repeat submissions succeed without creating duplicates).
- `SubscribeForm`/`SubscribeButton`/`SubscribePopup` components, plus a global `SubscribeProvider` mounted around the whole app (covers Bio, which bypasses `PublicLayout`).
- `useIdleSubscribe` hook opens the popup after ~60s of inactivity on any page, dismissible once per browser session via `sessionStorage`.
- Consolidated the `sonner` `Toaster` into `SubscribeProvider` (was previously duplicated in `Contact.tsx`) so only one toast host is mounted app-wide.
- Placement of `SubscribeForm`/`SubscribeButton` on specific named pages is deferred until those pages are chosen — this PR ships the global popup and reusable components only.

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` — clean
- [x] `php artisan test --filter=Subscri` — 5/5 passing (valid email, required/format validation, idempotent repeat, no source/referrer)
- [x] Live: idle popup opens on homepage and on `/bio` after inactivity, submits successfully, dismiss suppresses it for the session
- [x] Live: resubmitting the same email returns success with no duplicate row (verified via DB count)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE