### PR TITLE
Redesign subscribe popup, add Bio subscribe button label

### DIFF
--- a/.claude/agents/ui-designer.md
+++ b/.claude/agents/ui-designer.md
@@ -1,0 +1,29 @@
+---
+name: ui-designer
+description: Use PROACTIVELY when a React/Tailwind component's visual design needs to be created or redesigned (layout, spacing, typography, color, motion). Not for backend logic or plain bug fixes.
+tools: Read, Edit, Write, Grep, Glob, Bash
+model: opus
+---
+
+You are a senior product UI designer who also writes production React + Tailwind CSS code. You work on this Laravel + Inertia.js + React 19 + TypeScript + Tailwind v4 portfolio site.
+
+## What you do
+
+- Redesign or create the visual design of a component: layout, spacing, typography, hierarchy, color, motion.
+- Keep all existing functionality and prop contracts intact unless the task explicitly asks you to change behavior.
+- Match the codebase's existing conventions: read nearby components and reuse the same color tokens, font classes (e.g. `font-mono`, `font-display`), spacing scale, and motion patterns (this project uses `framer-motion`) before inventing new ones.
+- When a component has multiple visual themes (e.g. `warm` vs `slate`), preserve the theme system and apply your redesign to every theme consistently.
+- Prefer small, surgical Tailwind class changes and JSX restructuring over introducing new dependencies.
+
+## Process
+
+1. Read the target component(s) and at least one sibling/parent component to learn the established design language (colors, type scale, border radius, shadow style).
+2. State the concrete design direction you're taking in one or two sentences before editing.
+3. Make the edits.
+4. Run `npx tsc --noEmit` to confirm the change type-checks.
+
+## What you don't do
+
+- Don't touch backend/controller/route files.
+- Don't add new npm dependencies without flagging it first.
+- Don't rewrite copy/prose — that's a separate concern (humanizer skill handles copy).

--- a/resources/js/Components/SubscribeForm.tsx
+++ b/resources/js/Components/SubscribeForm.tsx
@@ -1,6 +1,7 @@
 import { useState, FormEvent } from 'react'
 import { router } from '@inertiajs/react'
 import { toast } from 'sonner'
+import { ArrowRight } from 'lucide-react'
 import { Input } from '@/Components/ui/input'
 import { Button } from '@/Components/ui/button'
 import { cn } from '@/lib/utils'
@@ -9,13 +10,15 @@ export type SubscribeTheme = 'warm' | 'slate'
 
 const THEME = {
   warm: {
-    input: 'bg-white border-[#e4d7c4] focus-visible:ring-[#b8541f] text-[#2b2320] placeholder:text-[#8a6a45]',
-    button: 'bg-[#b8541f] hover:bg-[#9c4419] text-white',
+    input:
+      'bg-white border-[#e4d7c4] focus-visible:ring-[#b8541f]/30 focus-visible:border-[#c98a4b] text-[#2b2320] placeholder:text-[#a08a6f]',
+    button: 'bg-[#b8541f] hover:bg-[#9c4419] text-white shadow-sm shadow-[#b8541f]/25',
     error: 'text-[#b8541f]',
   },
   slate: {
-    input: 'bg-white border-slate-200 focus-visible:ring-slate-500 text-slate-950 placeholder:text-slate-400',
-    button: 'bg-slate-900 hover:bg-slate-800 text-white',
+    input:
+      'bg-white border-slate-200 focus-visible:ring-slate-400/30 focus-visible:border-slate-300 text-slate-950 placeholder:text-slate-400',
+    button: 'bg-slate-900 hover:bg-slate-800 text-white shadow-sm',
     error: 'text-red-600',
   },
 } as const
@@ -62,21 +65,31 @@ export function SubscribeForm({
   }
 
   return (
-    <form onSubmit={handleSubmit} className={cn('flex flex-col gap-2', className)}>
-      <div className="flex flex-col gap-2 sm:flex-row">
-        <Input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="you@example.com"
-          required
-          className={cn('h-11', t.input)}
-        />
-        <Button type="submit" disabled={isSubmitting} className={cn('h-11 shrink-0 px-5', t.button)}>
-          {isSubmitting ? 'Subscribing…' : 'Subscribe'}
-        </Button>
-      </div>
-      {error && <p className={cn('text-sm', t.error)}>{error}</p>}
+    <form onSubmit={handleSubmit} className={cn('flex flex-col gap-2.5', className)}>
+      <Input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="you@example.com"
+        required
+        aria-label="Email address"
+        className={cn('h-12 rounded-full px-5 text-sm', t.input)}
+      />
+      <Button
+        type="submit"
+        disabled={isSubmitting}
+        className={cn('group h-12 w-full gap-2 rounded-full text-sm font-semibold', t.button)}
+      >
+        {isSubmitting ? (
+          'Subscribing…'
+        ) : (
+          <>
+            Subscribe
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+          </>
+        )}
+      </Button>
+      {error && <p className={cn('px-1 text-xs', t.error)}>{error}</p>}
     </form>
   )
 }

--- a/resources/js/Components/SubscribePopup.tsx
+++ b/resources/js/Components/SubscribePopup.tsx
@@ -1,28 +1,53 @@
 import { createPortal } from 'react-dom'
-import { motion, AnimatePresence } from 'framer-motion'
-import { X, Mail } from 'lucide-react'
+import { motion, AnimatePresence, type Variants } from 'framer-motion'
+import { X, Mail, ShieldCheck } from 'lucide-react'
 import { SubscribeForm, SubscribeTheme } from '@/Components/SubscribeForm'
 
 const THEME = {
   warm: {
-    backdrop: 'bg-[#2b2320]/80',
-    panel: 'bg-[#fffaf6]',
-    border: 'border-[#e4d7c4]',
-    title: 'text-[#2b2320]',
-    muted: 'text-[#8a6a45]',
-    iconBg: 'bg-[#f1e6d3] text-[#b8541f]',
-    close: 'text-[#8a6a45] hover:bg-[#f1e6d3] hover:text-[#2b2320]',
+    backdrop: 'bg-[#2b2320]/70',
+    panel: 'bg-[#fffaf6] border-[#e4d7c4]',
+    // Soft amber wash bleeding down from the top edge — echoes Bio's layered glow.
+    glow: 'bg-[radial-gradient(120%_90%_at_50%_-10%,rgba(217,157,89,0.20),transparent_60%)]',
+    iconTile: 'bg-gradient-to-br from-[#f6ecda] to-[#f0e2cd] text-[#b8541f] ring-1 ring-inset ring-[#e4d7c4]',
+    iconGlow: 'from-[#e8b374] to-[#b8541f]',
+    title: 'font-display font-semibold tracking-tight text-[#2b2320]',
+    lead: 'text-[#6b5d4f]',
+    fine: 'text-[#8a6a45]',
+    fineIcon: 'text-[#b8541f]',
+    close:
+      'border-[#e4d7c4] text-[#8a6a45] hover:bg-[#f1e6d3] hover:text-[#2b2320] focus-visible:ring-[#b8541f]',
   },
   slate: {
-    backdrop: 'bg-slate-950/80',
-    panel: 'bg-white',
-    border: 'border-slate-200',
-    title: 'text-slate-950',
-    muted: 'text-slate-500',
-    iconBg: 'bg-slate-100 text-slate-700',
-    close: 'text-slate-500 hover:bg-slate-100 hover:text-slate-950',
+    backdrop: 'bg-slate-950/70',
+    panel: 'bg-white border-slate-200',
+    glow: 'bg-[radial-gradient(120%_90%_at_50%_-10%,rgba(100,116,139,0.12),transparent_60%)]',
+    iconTile: 'bg-gradient-to-br from-slate-50 to-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200',
+    iconGlow: 'from-slate-300 to-slate-500',
+    title: 'font-semibold tracking-tight text-slate-950',
+    lead: 'text-slate-500',
+    fine: 'text-slate-400',
+    fineIcon: 'text-slate-400',
+    close:
+      'border-slate-200 text-slate-400 hover:bg-slate-100 hover:text-slate-950 focus-visible:ring-slate-400',
   },
 } as const
+
+const panelVariants: Variants = {
+  hidden: { opacity: 0, scale: 0.96, y: 12 },
+  show: {
+    opacity: 1,
+    scale: 1,
+    y: 0,
+    transition: { type: 'spring', stiffness: 280, damping: 24, staggerChildren: 0.06, delayChildren: 0.04 },
+  },
+  exit: { opacity: 0, scale: 0.97, y: 8, transition: { duration: 0.15, ease: 'easeIn' } },
+}
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 8 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+}
 
 export function SubscribePopup({
   open,
@@ -53,32 +78,54 @@ export function SubscribePopup({
           onClick={onClose}
         >
           <motion.div
-            initial={{ opacity: 0, scale: 0.96, y: 8 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.96, y: 8 }}
-            transition={{ duration: 0.18, ease: 'easeOut' }}
-            className={`relative w-full max-w-sm rounded-2xl border ${t.border} ${t.panel} p-6 shadow-2xl`}
+            variants={panelVariants}
+            initial="hidden"
+            animate="show"
+            exit="exit"
+            className={`relative w-full max-w-sm overflow-hidden rounded-3xl border ${t.panel} p-6 shadow-2xl sm:p-7`}
             onClick={(e) => e.stopPropagation()}
           >
+            {/* Decorative glow that spills from the top edge inside the panel. */}
+            <div aria-hidden="true" className={`pointer-events-none absolute inset-x-0 top-0 h-40 ${t.glow}`} />
+
             <button
               type="button"
               onClick={onClose}
               aria-label="Close"
-              className={`absolute right-3 top-3 rounded-full p-1.5 transition ${t.close}`}
+              className={`absolute right-3.5 top-3.5 flex h-8 w-8 items-center justify-center rounded-full border transition hover:scale-105 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${t.close}`}
             >
               <X className="h-4 w-4" />
             </button>
 
-            <span className={`flex h-10 w-10 items-center justify-center rounded-full ${t.iconBg}`}>
-              <Mail className="h-5 w-5" />
-            </span>
+            <div className="relative">
+              {/* Icon tile with a soft halo behind it. */}
+              <motion.div variants={itemVariants} className="relative inline-flex">
+                <span
+                  aria-hidden="true"
+                  className={`absolute inset-0 scale-[1.35] rounded-2xl bg-gradient-to-br ${t.iconGlow} opacity-30 blur-lg`}
+                />
+                <span className={`relative flex h-12 w-12 items-center justify-center rounded-2xl ${t.iconTile}`}>
+                  <Mail className="h-5 w-5" />
+                </span>
+              </motion.div>
 
-            <h2 className={`mt-4 text-lg font-semibold ${t.title}`}>Get new posts and tools first</h2>
-            <p className={`mt-1 text-sm ${t.muted}`}>
-              I send an email when there's something worth reading. No spam, unsubscribe anytime.
-            </p>
+              <motion.div variants={itemVariants} className="mt-4 space-y-2">
+                <h2 className={`text-xl ${t.title}`}>Get new posts and tools first</h2>
+                <div className="space-y-1.5">
+                  <p className={`text-sm leading-relaxed ${t.lead}`}>
+                    I send an email when there&apos;s something worth reading.
+                  </p>
+                  <p className={`flex items-center gap-1.5 text-xs ${t.fine}`}>
+                    <ShieldCheck className={`h-3.5 w-3.5 shrink-0 ${t.fineIcon}`} />
+                    No spam, unsubscribe anytime.
+                  </p>
+                </div>
+              </motion.div>
 
-            <SubscribeForm source={source} theme={theme} onSuccess={onClose} className="mt-4" />
+              <motion.div variants={itemVariants} className="mt-5">
+                <SubscribeForm source={source} theme={theme} onSuccess={onClose} />
+              </motion.div>
+            </div>
           </motion.div>
         </motion.div>
       )}

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -381,10 +381,10 @@ export default function Bio({
             <button
               type="button"
               onClick={() => openPopup('bio-header', 'warm')}
-              aria-label="Subscribe"
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
+              className="flex h-10 items-center gap-1.5 rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 px-4 font-mono text-xs font-medium uppercase tracking-wider text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
             >
               <Mail className="h-4 w-4" />
+              Subscribe
             </button>
 
             <div className="relative" ref={openMenu === 'page' ? menuRef : null}>


### PR DESCRIPTION
## Summary
- Redesigns `SubscribePopup`/`SubscribeForm`: gradient icon tile, themed type hierarchy (serif on warm, sans on slate), staggered entrance motion, full-width pill input/button, more considered close button
- Splits the "No spam, unsubscribe anytime." reassurance onto its own line with a shield icon, separate from the main sentence
- Bio's header subscribe button now reads "Subscribe" next to the mail icon instead of icon-only
- Adds `.claude/agents/ui-designer.md`, an Opus-powered subagent for future visual-design work

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Verified locally: warm theme (Bio) and slate theme (default idle popup) both render correctly, close button works
- [x] Verified Bio's new button label doesn't break existing share button layout

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE