### PR TITLE
Add Cashback tab to Bio page

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -59,6 +59,7 @@ const SOCIAL_TRAILING = ['globe', 'mail']
 const DECLARED_TABS = [
   { slug: 'products', label: 'Products' },
   { slug: 'ai-tools', label: 'AI Tools' },
+  { slug: 'cashback', label: 'Cashback' },
 ]
 
 /** POST a click event to the server (fire-and-forget with keepalive). */


### PR DESCRIPTION
## Summary
- Adds a "Cashback" tab to the `/bio` page's declared tabs, positioned after "AI Tools"
- Shows the existing "Coming soon." empty state until a link is added

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Verified locally: tab renders, click switches to it, empty state shows

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Cashback” tab to the bio page.
  * Displays a “Coming soon” message when cashback links are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->