### PR TITLE
Seed cashback links, add tab dividers, rename AI Tools to AI/ML

### DIFF
--- a/database/migrations/2026_07_25_123440_seed_cashback_bio_links.php
+++ b/database/migrations/2026_07_25_123440_seed_cashback_bio_links.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\BioLink;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Seeds the /bio "Cashback" tab: a worldwide default (TopCashback's US store)
+ * plus two country-locked entries. The US entry stays alongside the default
+ * for US visitors; the AU entry replaces the default for AU visitors (the
+ * default excludes AU so the two don't both show there).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Data-seed migration, not schema: skip in the testing environment so
+        // it doesn't pollute the fresh `bio_links` table RefreshDatabase gives
+        // each test.
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        BioLink::updateOrCreate(
+            ['url' => 'https://www.topcashback.com/ref/harunrrayhan'],
+            [
+                'label' => 'TopCashback',
+                'description' => 'Get cashback on your online purchases.',
+                'icon' => 'shop',
+                'tab' => 'Cashback',
+                'priority' => 10,
+                'is_active' => true,
+                'featured' => false,
+                'exclude_countries' => ['AU'],
+            ]
+        );
+
+        BioLink::updateOrCreate(
+            ['url' => 'https://www.topcashback.com/ref/harunrrayhan', 'label' => 'TopCashback (US)'],
+            [
+                'description' => 'Get cashback on your online purchases.',
+                'icon' => 'shop',
+                'tab' => 'Cashback',
+                'priority' => 20,
+                'is_active' => true,
+                'featured' => false,
+                'include_countries' => ['US'],
+            ]
+        );
+
+        BioLink::updateOrCreate(
+            ['url' => 'https://www.topcashback.com.au/ref/harunrrayhan'],
+            [
+                'label' => 'TopCashback (AU)',
+                'description' => 'Get cashback on your online purchases.',
+                'icon' => 'shop',
+                'tab' => 'Cashback',
+                'priority' => 30,
+                'is_active' => true,
+                'featured' => false,
+                'include_countries' => ['AU'],
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        BioLink::where('url', 'https://www.topcashback.com.au/ref/harunrrayhan')->delete();
+        BioLink::where('url', 'https://www.topcashback.com/ref/harunrrayhan')->delete();
+    }
+};

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -58,7 +58,7 @@ const SOCIAL_TRAILING = ['globe', 'mail']
 // A declared tab with no links shows a "Coming soon" panel instead of hiding.
 const DECLARED_TABS = [
   { slug: 'products', label: 'Products' },
-  { slug: 'ai-tools', label: 'AI Tools' },
+  { slug: 'ai-tools', label: 'AI/ML' },
   { slug: 'cashback', label: 'Cashback' },
 ]
 
@@ -471,44 +471,51 @@ export default function Bio({
                   aria-label="Link categories"
                   className="flex w-full gap-1 overflow-x-auto rounded-full border border-[#e4d7c4] bg-[#fffaf6]/70 p-1"
                 >
-                  {tabGroups.map((group) => {
+                  {tabGroups.map((group, idx) => {
                     const isActive = group.slug === activeSlug
                     const shareId = `tab:${group.slug}` as const
+                    // A divider between two inactive tabs marks where one ends
+                    // and the next begins — skipped next to the active pill,
+                    // since its own background already reads as a boundary.
+                    const prevActive = idx > 0 && tabGroups[idx - 1].slug === activeSlug
+                    const showDivider = idx > 0 && !isActive && !prevActive
                     return (
-                      <div
-                        key={group.slug}
-                        className={`relative flex flex-1 items-center justify-center whitespace-nowrap rounded-full font-mono text-xs font-medium uppercase tracking-wider transition sm:text-[13px] ${
-                          isActive
-                            ? 'bg-[#2b2320] text-[#f7f1e8] shadow-sm'
-                            : 'text-[#6b5d4f] hover:bg-[#f1e6d3] hover:text-[#2b2320]'
-                        }`}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => setActiveSlug(group.slug)}
-                          aria-pressed={isActive}
-                          className="flex-1 rounded-full px-3.5 py-2 uppercase tracking-wider focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
+                      <React.Fragment key={group.slug}>
+                        {showDivider && <span aria-hidden="true" className="my-1.5 w-px shrink-0 self-stretch bg-[#e4d7c4]" />}
+                        <div
+                          className={`relative flex flex-1 items-center justify-center whitespace-nowrap rounded-full font-mono text-xs font-medium uppercase tracking-wider transition sm:text-[13px] ${
+                            isActive
+                              ? 'bg-[#2b2320] text-[#f7f1e8] shadow-sm'
+                              : 'text-[#6b5d4f] hover:bg-[#f1e6d3] hover:text-[#2b2320]'
+                          }`}
                         >
-                          {displayTab(group.label)}
-                        </button>
-
-                        {/* Share button (visible on the active tab, a sibling
-                            of the select button so this isn't an interactive
-                            control nested inside another one). */}
-                        {isActive && (
                           <button
                             type="button"
-                            onClick={() => setOpenMenu(openMenu === shareId ? null : shareId)}
-                            aria-label={`Share ${displayTab(group.label)}`}
-                            aria-haspopup="menu"
-                            aria-expanded={openMenu === shareId}
-                            title={`Share ${displayTab(group.label)}`}
-                            className="mr-2 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-70 transition hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f] sm:h-4 sm:w-4"
+                            onClick={() => setActiveSlug(group.slug)}
+                            aria-pressed={isActive}
+                            className="flex-1 rounded-full px-3.5 py-2 uppercase tracking-wider focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
                           >
-                            <Share2 className="h-3 w-3" />
+                            {displayTab(group.label)}
                           </button>
-                        )}
-                      </div>
+
+                          {/* Share button (visible on the active tab, a sibling
+                              of the select button so this isn't an interactive
+                              control nested inside another one). */}
+                          {isActive && (
+                            <button
+                              type="button"
+                              onClick={() => setOpenMenu(openMenu === shareId ? null : shareId)}
+                              aria-label={`Share ${displayTab(group.label)}`}
+                              aria-haspopup="menu"
+                              aria-expanded={openMenu === shareId}
+                              title={`Share ${displayTab(group.label)}`}
+                              className="mr-2 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-70 transition hover:opacity-100 focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f] sm:h-4 sm:w-4"
+                            >
+                              <Share2 className="h-3 w-3" />
+                            </button>
+                          )}
+                        </div>
+                      </React.Fragment>
                     )
                   })}
                 </nav>


### PR DESCRIPTION
## Summary
- Seeds the Cashback tab's TopCashback links via a data migration (same pattern as the Products tab seed): a worldwide default excluding AU, a US-only entry, and an AU-only entry.
- Adds a visual divider between adjacent tab pills when neither is selected, so unselected tabs don't visually run together.
- Renames the "AI Tools" tab label to "AI/ML" (slug unchanged, so no data migration needed).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Migration runs and rolls back cleanly locally (`php artisan migrate` / `migrate:rollback`), verified via tinker that the three rows have correct `include_countries`/`exclude_countries`
- [x] Verified in local browser: AI/ML label renders, dividers appear between inactive tabs only, Cashback tab shows the General TopCashback link (US/AU-only entries correctly hidden for an unresolved local IP)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE