### PR TITLE
Show cashback US/AU links to everyone

### DIFF
--- a/database/migrations/2026_07_25_132449_show_cashback_country_links_to_everyone.php
+++ b/database/migrations/2026_07_25_132449_show_cashback_country_links_to_everyone.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\BioLink;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * The US-only and AU-only cashback entries were originally gated by
+ * `include_countries`, so a visitor only saw the store link matching their
+ * own detected country. That hid both from anyone whose country couldn't be
+ * resolved, and hid the "other" one from everyone. These should be visible
+ * to all visitors instead, listed below the (still country-aware) General
+ * entry, so people can manually pick either store regardless of geo
+ * detection.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        BioLink::where('tab', 'Cashback')
+            ->whereIn('label', ['TopCashback (US)', 'TopCashback (AU)'])
+            ->update(['include_countries' => null]);
+    }
+
+    public function down(): void
+    {
+        BioLink::where('tab', 'Cashback')
+            ->where('label', 'TopCashback (US)')
+            ->update(['include_countries' => ['US']]);
+
+        BioLink::where('tab', 'Cashback')
+            ->where('label', 'TopCashback (AU)')
+            ->update(['include_countries' => ['AU']]);
+    }
+};


### PR DESCRIPTION
## Summary
- The General cashback entry stays geo-aware (hidden from AU, so those visitors see the AU-only link as their default).
- The US-only and AU-only entries drop their `include_countries` restriction so every visitor sees both, listed below General, and can manually pick either store regardless of detected location.

## Test plan
- [x] Migration runs and rolls back cleanly locally, verified via tinker that visibility is correct for unknown/AU/US countries
- [x] Verified in local browser: Cashback tab now shows all three entries (General, US, AU) for a visitor with no resolved country

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cashback links for TopCashback (US) and TopCashback (AU) are now visible regardless of the visitor’s location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->