### PR TITLE
Geo-route the General TopCashback link, add opencode bio link

### DIFF
--- a/app/Models/ShortLink.php
+++ b/app/Models/ShortLink.php
@@ -12,6 +12,7 @@ class ShortLink extends Model
     protected $fillable = [
         'code',
         'destination_url',
+        'country_overrides',
         'url_hash',
         'title',
         'is_active',
@@ -21,6 +22,7 @@ class ShortLink extends Model
     protected $casts = [
         'is_active' => 'boolean',
         'expires_at' => 'datetime',
+        'country_overrides' => 'array',
     ];
 
     protected $appends = ['short_url'];
@@ -136,6 +138,22 @@ class ShortLink extends Model
     public function getShortUrlAttribute(): string
     {
         return url('/s/'.$this->code);
+    }
+
+    /**
+     * The redirect target for a visitor from $country: their country's
+     * override if one is set, otherwise the plain destination_url. Lets one
+     * shared/copied link fan out by geography (e.g. AU visitors land on the
+     * AU store, everyone else keeps the default) without needing a separate
+     * short code per country.
+     */
+    public function resolveDestination(?string $country): string
+    {
+        if ($country && isset($this->country_overrides[$country])) {
+            return $this->country_overrides[$country];
+        }
+
+        return $this->destination_url;
     }
 
     public function scopeActive(Builder $query): Builder

--- a/database/migrations/2026_07_25_140000_add_country_overrides_to_short_links_table.php
+++ b/database/migrations/2026_07_25_140000_add_country_overrides_to_short_links_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('short_links', function (Blueprint $table) {
+            $table->json('country_overrides')->nullable()->after('destination_url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('short_links', function (Blueprint $table) {
+            $table->dropColumn('country_overrides');
+        });
+    }
+};

--- a/database/migrations/2026_07_25_140500_geo_route_general_cashback_short_link.php
+++ b/database/migrations/2026_07_25_140500_geo_route_general_cashback_short_link.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\BioLink;
+use App\Models\ShortLink;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * The General cashback entry and the US-only entry point at the same
+ * destination URL, so they'd shared one auto-deduped ShortLink row. That's a
+ * problem now: the General link's short/share URL needs to redirect AU
+ * visitors to the AU store while everyone else keeps landing on the US
+ * store, but the US-only link must always land on the US store regardless
+ * of visitor location. Sharing a short code would geo-redirect both.
+ *
+ * This gives the General entry its own ShortLink row (same US destination,
+ * plus an AU override) and repoints its short_link_id there, leaving the
+ * US-only entry on the original, override-free row.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        $general = BioLink::where('tab', 'Cashback')->where('label', 'TopCashback')->first();
+
+        if (! $general) {
+            return;
+        }
+
+        $shortLink = ShortLink::create([
+            'destination_url' => 'https://www.topcashback.com/ref/harunrrayhan',
+            'country_overrides' => ['AU' => 'https://www.topcashback.com.au/ref/harunrrayhan'],
+            'title' => 'TopCashback (geo-routed)',
+        ]);
+
+        BioLink::where('id', $general->id)->update(['short_link_id' => $shortLink->id]);
+    }
+
+    public function down(): void
+    {
+        $general = BioLink::where('tab', 'Cashback')->where('label', 'TopCashback')->first();
+
+        if (! $general) {
+            return;
+        }
+
+        $shared = ShortLink::where('url_hash', ShortLink::hashFor('https://www.topcashback.com/ref/harunrrayhan'))
+            ->where('title', 'TopCashback')
+            ->first();
+
+        $geoRouted = ShortLink::where('title', 'TopCashback (geo-routed)')->first();
+
+        if ($shared) {
+            BioLink::where('id', $general->id)->update(['short_link_id' => $shared->id]);
+        }
+
+        $geoRouted?->delete();
+    }
+};

--- a/database/migrations/2026_07_25_141500_seed_opencode_bio_link.php
+++ b/database/migrations/2026_07_25_141500_seed_opencode_bio_link.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\BioLink;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Seeds the /bio "AI/ML" tab (declared as slug 'ai-tools' in Bio.tsx, tab
+ * label overridden to "AI/ML") with its first real entry: a referral link
+ * for opencode. `tab` stays 'AI Tools' so BioLink::booted() derives the
+ * 'ai-tools' slug and the link lands in the existing declared tab instead of
+ * spawning a duplicate "AI/ML" group.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        BioLink::updateOrCreate(
+            ['url' => 'https://opencode.ai/go?ref=WZW046PT99'],
+            [
+                'label' => 'opencode',
+                'description' => 'Sign up with my link and get $5 extra credit.',
+                'icon' => 'link',
+                'tab' => 'AI Tools',
+                'priority' => 10,
+                'is_active' => true,
+                'featured' => false,
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        BioLink::where('url', 'https://opencode.ai/go?ref=WZW046PT99')->delete();
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -130,15 +130,17 @@ Route::get('/s/{code}', function (string $code, Request $request, CountryResolve
 
     abort_unless($link, 404);
 
+    $country = $countries->resolve($request->ip());
+
     ShortLinkClick::create([
         'short_link_id' => $link->id,
         'ip_address' => $request->ip(),
-        'country' => $countries->resolve($request->ip()),
+        'country' => $country,
         'user_agent' => $request->userAgent(),
         'referer' => $request->header('referer'),
     ]);
 
-    return redirect()->away($link->destination_url, 302);
+    return redirect()->away($link->resolveDestination($country), 302);
 })->name('short.redirect');
 
 // Public link-in-bio landing page (DB-driven, no auth)

--- a/tests/Feature/ShortLinkTest.php
+++ b/tests/Feature/ShortLinkTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\ShortLink;
 use App\Models\ShortLinkClick;
 use App\Models\User;
+use App\Services\CountryResolver;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -124,6 +125,34 @@ class ShortLinkTest extends TestCase
         $this->assertNull(ShortLink::getOrCreateForUrl('/bio'));
         $this->assertNull(ShortLink::getOrCreateForUrl('mailto:harun@harun.dev'));
         $this->assertSame(0, ShortLink::count());
+    }
+
+    public function test_a_country_override_redirects_a_matching_visitor_elsewhere(): void
+    {
+        $link = ShortLink::create([
+            'destination_url' => 'https://example.com/us',
+            'country_overrides' => ['AU' => 'https://example.com/au'],
+        ]);
+
+        $this->mock(CountryResolver::class)
+            ->shouldReceive('resolve')
+            ->andReturn('AU');
+
+        $this->get("/s/{$link->code}")->assertRedirect('https://example.com/au');
+    }
+
+    public function test_a_country_override_leaves_other_visitors_on_the_default_destination(): void
+    {
+        $link = ShortLink::create([
+            'destination_url' => 'https://example.com/us',
+            'country_overrides' => ['AU' => 'https://example.com/au'],
+        ]);
+
+        $this->mock(CountryResolver::class)
+            ->shouldReceive('resolve')
+            ->andReturn(null);
+
+        $this->get("/s/{$link->code}")->assertRedirect('https://example.com/us');
     }
 
     public function test_creating_via_admin_with_an_already_shortened_url_reuses_it(): void


### PR DESCRIPTION
## Summary
- Short links now support per-country destination overrides. The General TopCashback share link redirects AU visitors to the AU store and everyone else to the US store; the existing US-only share link is unaffected (its own ShortLink row, no override).
- Seeds the AI/ML tab's first bio link entry: an opencode referral link with a $5-credit description.

## Test plan
- [x] `php artisan test --filter=ShortLinkTest` — 21 passing
- [x] Verified locally via tinker: General link resolves AU → AU store, US/null → US store; US-only link stays on the US store regardless of country
- [x] Verified opencode bio link lands in the `ai-tools` tab slug with a working short link
- [x] Pint clean on all new/touched files (pre-existing violations in `ShortLink.php`/`routes/web.php` confirmed via stash comparison, out of scope)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE