### PR TITLE
Unify bio-link icons across all tabs

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -146,19 +146,21 @@ const PRODUCT_LOGOS: Record<string, string> = {
   'https://amazingplugins.com': '/images/products/amazingplugins.jpg',
 }
 
-/** Standard-row icon: a product's real logo in a bordered box when it has
- *  one, otherwise the small favicon/registry icon. */
+/** Standard-row icon: a product's real logo when it has one, otherwise the
+ *  site's real favicon (falling back to the registry icon). Either way it
+ *  renders in the same bordered box, so every tab reads consistently. */
 function LinkIcon({ link }: { link: BioLink }) {
   const logo = PRODUCT_LOGOS[link.url]
-  if (logo) {
-    return (
-      <span className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-[#e4d7c4] bg-white sm:h-12 sm:w-12">
-        <img src={logo} alt="" className="h-7 w-7 object-contain sm:h-8 sm:w-8" />
-      </span>
-    )
-  }
 
-  return <LinkFavicon link={link} className="h-4 w-4 shrink-0 text-[#8a6a45]" />
+  return (
+    <span className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-[#e4d7c4] bg-white sm:h-12 sm:w-12">
+      {logo ? (
+        <img src={logo} alt="" className="h-7 w-7 object-contain sm:h-8 sm:w-8" />
+      ) : (
+        <LinkFavicon link={link} className="h-7 w-7 text-[#8a6a45] sm:h-8 sm:w-8" />
+      )}
+    </span>
+  )
 }
 
 /** The per-link share trigger (share icon button) plus its ShareSheet, self-contained. */


### PR DESCRIPTION
## Summary
- AI/ML and Cashback bio links previously showed a tiny unboxed favicon (or nothing), while Products showed real logos in a bordered box.
- `LinkIcon` now always renders inside the same bordered box: product logo when hardcoded, otherwise the site's real favicon (falling back to the registry icon).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Verified locally in Chrome: Products (no regression, real logos still boxed), AI/ML (opencode entry now shows boxed favicon), Cashback (all 3 TopCashback entries now show boxed favicon)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE