### PR TITLE
Split bio AI/ML tab into AI and Tools

### DIFF
--- a/database/migrations/2026_07_25_150000_rename_ai_tools_bio_tab_to_ai.php
+++ b/database/migrations/2026_07_25_150000_rename_ai_tools_bio_tab_to_ai.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\BioLink;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * The "AI Tools" bio tab (slug 'ai-tools') is now just "AI" (slug 'ai') --
+ * general dev tools are moving to their own new "Tools" tab instead of
+ * sharing this one. Existing links only need their `tab` string updated;
+ * BioLink::booted() re-derives `tab_slug` from it on save.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        BioLink::where('tab_slug', 'ai-tools')->get()->each(function (BioLink $link) {
+            $link->update(['tab' => 'AI']);
+        });
+    }
+
+    public function down(): void
+    {
+        BioLink::where('tab_slug', 'ai')->get()->each(function (BioLink $link) {
+            $link->update(['tab' => 'AI Tools']);
+        });
+    }
+};

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -58,7 +58,8 @@ const SOCIAL_TRAILING = ['globe', 'mail']
 // A declared tab with no links shows a "Coming soon" panel instead of hiding.
 const DECLARED_TABS = [
   { slug: 'products', label: 'Products' },
-  { slug: 'ai-tools', label: 'AI/ML' },
+  { slug: 'ai', label: 'AI' },
+  { slug: 'tools', label: 'Tools' },
   { slug: 'cashback', label: 'Cashback' },
 ]
 


### PR DESCRIPTION
## Summary
- Renamed the bio "AI/ML" tab to "AI" (slug `ai-tools` → `ai`).
- Added a new always-visible "Tools" tab for general dev-tool links, separate from AI-specific ones.
- Migrated the existing opencode link's `tab` so it stays under the new AI slug.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Ran the migration locally, confirmed opencode link's `tab_slug` is now `ai`
- [x] Verified locally in Chrome: Products/AI/Tools/Cashback tabs all render in order, AI shows the opencode entry, Tools shows the "Coming soon" empty state

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split the combined AI/ML section into separate **AI** and **Tools** tabs.
  * Updated existing AI links to appear under the **AI** tab.
  * Preserved tab ordering and availability on bio pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->