### PR TITLE
Relabel bio AI tab back to AI/ML

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -58,7 +58,7 @@ const SOCIAL_TRAILING = ['globe', 'mail']
 // A declared tab with no links shows a "Coming soon" panel instead of hiding.
 const DECLARED_TABS = [
   { slug: 'products', label: 'Products' },
-  { slug: 'ai', label: 'AI' },
+  { slug: 'ai', label: 'AI/ML' },
   { slug: 'tools', label: 'Tools' },
   { slug: 'cashback', label: 'Cashback' },
 ]


### PR DESCRIPTION
## Summary
- The bio "AI" tab pill now reads "AI/ML" again. Only the display label changes; the `ai` slug and existing BioLink data are untouched.

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] Verified locally: pill shows "AI/ML"
- [ ] Verify live on harun.dev after deploy

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE