### PR TITLE
Move Cashback tab before Tools on bio page

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -59,8 +59,8 @@ const SOCIAL_TRAILING = ['globe', 'mail']
 const DECLARED_TABS = [
   { slug: 'products', label: 'Products' },
   { slug: 'ai', label: 'AI/ML' },
-  { slug: 'tools', label: 'Tools' },
   { slug: 'cashback', label: 'Cashback' },
+  { slug: 'tools', label: 'Tools' },
 ]
 
 /** POST a click event to the server (fire-and-forget with keepalive). */


### PR DESCRIPTION
## Summary
- Reorders the /bio tab pills: Products, AI/ML, Cashback, Tools (was Products, AI/ML, Tools, Cashback)

## Test plan
- [x] `npx tsc --noEmit` passes

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE