### PR TITLE
Resync the stale YouTube short link on production

### DIFF
--- a/database/migrations/2026_07_25_170000_resync_youtube_short_link.php
+++ b/database/migrations/2026_07_25_170000_resync_youtube_short_link.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\BioLink;
+use App\Models\ShortLink;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * 2026_07_25_161500_update_youtube_bio_link_url set the YouTube BioLink's
+ * `url` via a mass `Builder::update()`, which bypasses BioLink::booted()'s
+ * `saving` hook -- so `short_link_id` was never repointed and the public
+ * short link (/s/{code}) kept redirecting to the old channel. This resolves
+ * (or creates) the ShortLink for the row's current url and repoints
+ * short_link_id, replicating what the hook would have done on a normal save.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        $link = BioLink::where('icon', 'youtube')->first();
+
+        if (! $link) {
+            return;
+        }
+
+        $shortLink = ShortLink::getOrCreateForUrl($link->url, $link->label);
+
+        BioLink::where('id', $link->id)->update(['short_link_id' => $shortLink?->id]);
+    }
+
+    public function down(): void
+    {
+        // Intentionally irreversible: there's no reliable record of which
+        // short link this row pointed to before this migration ran.
+    }
+};


### PR DESCRIPTION
## Summary
- The YouTube channel URL update in `2026_07_25_161500_update_youtube_bio_link_url` used a mass `Builder::update()`, which bypasses `BioLink::booted()`'s `saving` hook that repoints `short_link_id` to a `ShortLink` matching the new destination
- Production's public short link (`/s/jVZqUHU`) kept redirecting to the old YouTube channel instead of the new one with `?sub_confirmation=1`, which is what shows YouTube's native subscribe-confirmation prompt
- This migration resolves (or creates) a `ShortLink` for the row's current `url` and repoints `short_link_id`, replicating what the hook would have done on a normal save

## Test plan
- [x] Verified the failure mode and fix logic in a rolled-back local transaction (stale short link keeps its old destination, `BioLink` repoints to a fresh correct one)
- [x] `php artisan migrate --force` runs clean locally
- [x] `php artisan test --filter="BioLinkShortLinkTest|ShortLinkTest|BioLinkAnalyticsTest"` — 26 passed
- [ ] After deploy, confirm `/s/jVZqUHU`-style short link (or its new code, if reassigned) redirects to `https://www.youtube.com/@SkillupWithHarun?sub_confirmation=1` on production

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE