### PR TITLE
Show two-thirds of the fourth bio tab instead of half

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -519,10 +519,10 @@ export default function Bio({
                             if (el) tabRefs.current.set(group.slug, el)
                             else tabRefs.current.delete(group.slug)
                           }}
-                          // Fixed to ~29% of the strip's own width (not flex-1)
-                          // so roughly three and a half tabs show at once and
-                          // the rest signal themselves via horizontal scroll.
-                          className={`relative flex w-[29%] shrink-0 items-center justify-center whitespace-nowrap rounded-full font-mono text-xs font-bold uppercase tracking-wider transition sm:text-[13px] ${
+                          // Fixed to ~26.4% of the strip's own width (not
+                          // flex-1) so three full tabs plus two-thirds of a
+                          // fourth show at once, signaling more via scroll.
+                          className={`relative flex w-[26.4%] shrink-0 items-center justify-center whitespace-nowrap rounded-full font-mono text-xs font-bold uppercase tracking-wider transition sm:text-[13px] ${
                             isActive
                               ? 'bg-[#2b2320] text-[#f7f1e8] shadow-sm'
                               : 'text-[#6b5d4f] hover:bg-[#f1e6d3] hover:text-[#2b2320]'


### PR DESCRIPTION
## Summary
- The bio tab strip's fixed pill width was tuned for ~3.5 tabs visible by default; the user wants exactly three full tabs plus two-thirds of the fourth as the peek cue.
- Retuned the per-tab width from 29% (originally 3.5-tab math) to 26.4%, accounting for the divider and gap widths consumed between pills so the actual measured peek lands at ~67% of the fourth tab.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Verified in Chrome against local `php artisan serve`: measured the fourth tab's visible fraction via DOM rects (67.4%) and confirmed visually — Products, AI/ML, Cashback fully shown, Tools cut off after "TOOL".

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE