### PR TITLE
Fix draft preview token length for AI endpoints post

### DIFF
--- a/resources/blog/posts/ai-endpoints-post-generate-validation-lambda-bedrock-fastify.md
+++ b/resources/blog/posts/ai-endpoints-post-generate-validation-lambda-bedrock-fastify.md
@@ -4,7 +4,7 @@ slug: "ai-endpoints-post-generate-validation-lambda-bedrock-fastify"
 brief: "A Bedrock-backed Fastify route on Lambda needs a contract after the model answers, not just before it. Zod on the output, RAG context treated as untrusted data, one repair pass then a 422, idempotent SQS, and the CloudWatch metrics that catch it drifting."
 publishedAt: "2026-07-25T18:00:00.000Z"
 draft: true
-draftToken: "d0308e8ee8816e47936d4c92d1f9633d30ffc9d5"
+draftToken: "aca6297d619616dd555bd088805d274e"
 readTimeInMinutes: 12
 coverImageUrl: "/blog-assets/ai-endpoints-post-generate-validation-lambda-bedrock-fastify/cover.jpg"
 reactionCount: 0


### PR DESCRIPTION
## Summary
- The `blog.preview` route constrains `previewToken` to exactly 32 hex chars (`[A-Fa-f0-9]{32}`)
- The draftToken added in #82 was 40 chars (SHA1-length), so the preview URL never matched the route and 404'd unconditionally
- Regenerated a 32-char token (`openssl rand -hex 16`)

## Test plan
- [x] Confirmed via SSH into prod that `BlogRepository::find()`/`previewUrl()` already returned the correct data with the old token — the bug was purely the route regex length mismatch, not caching or deploy
- [ ] Verify the new draft URL loads after deploy

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE