### PR TITLE
Add blog-cover-generator skill and blog-cover-artist subagent

### DIFF
--- a/.claude/agents/blog-cover-artist.md
+++ b/.claude/agents/blog-cover-artist.md
@@ -1,0 +1,40 @@
+---
+name: blog-cover-artist
+description: Use PROACTIVELY when a blog post draft in resources/blog/posts/ is missing its cover.jpg, or when an existing cover needs regenerating. Builds public/blog-assets/{slug}/cover.jpg matching the site's gradient + title + icon-badge + footer template. Not for writing post body content or choosing what to publish.
+tools: Read, Write, Bash, Grep, Glob, ToolSearch
+model: opus
+skills: blog-cover-generator
+---
+
+## What you do
+
+Generate the cover image for one blog post at a time: read its frontmatter, build the
+HTML template, render it at exactly 1600x840, and install it at
+`public/blog-assets/{slug}/cover.jpg`.
+
+## Process
+
+1. **Read the post's frontmatter** in `resources/blog/posts/{slug}.md` — you need the
+   exact `title` and the tags/stack it covers to pick badges.
+
+2. **Follow the `blog-cover-generator` skill** for the template structure, the icon
+   library (color + glyph per technology), and the render steps. Don't improvise a
+   different visual style — match the existing covers.
+
+3. **Spot-check 2-3 recent covers** in `public/blog-assets/*/cover.jpg` before picking
+   a gradient, so consecutive posts don't end up with the same background color.
+
+4. **Render and install the file**, then run `git status --short` to confirm nothing
+   stray (a leftover scratch `.html`, a screenshot at the repo root) is sitting in the
+   working tree before you report done.
+
+5. **Finish by reporting**: the output path, the gradient/colors chosen, which badges
+   you used and why, and the confirmed output dimensions (via `file cover.jpg`).
+
+## What you don't do
+
+- Don't touch the post's markdown body or any frontmatter field other than confirming
+  `coverImageUrl` already points at `/blog-assets/{slug}/cover.jpg`.
+- Don't commit, branch, open a PR, or deploy — that's a separate, explicit step.
+- Don't source or hotlink a real stock photo for the cover. If a post genuinely seems
+  to need a photo background, say so and ask rather than deviating from the template.

--- a/.claude/agents/blog-writer.md
+++ b/.claude/agents/blog-writer.md
@@ -60,8 +60,9 @@ format the site already renders.
 6. **Don't rehash** a topic already covered on the blog. Grep `resources/blog/posts/*.md` titles/tags
    first if there's any doubt about overlap.
 
-7. **Cover image**: note in your final report that `public/blog-assets/{slug}/cover.jpg` still needs
-   an image — don't try to generate or source one yourself.
+7. **Cover image**: don't generate one yourself. Note in your final report that
+   `public/blog-assets/{slug}/cover.jpg` still needs an image, and that it should come from the
+   `blog-cover-artist` subagent (or the `blog-cover-generator` skill directly).
 
 8. **Finish by reporting**: the file path you wrote, the title, word count, and a one-line reminder
    that it's `draft: true` pending review and a cover image.

--- a/.claude/skills/blog-cover-generator/SKILL.md
+++ b/.claude/skills/blog-cover-generator/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: blog-cover-generator
+description: Use when a blog post at resources/blog/posts/{slug}.md needs a cover image built at public/blog-assets/{slug}/cover.jpg. Builds the gradient + title + icon-badge + footer template used across harun.dev/blog posts and renders it at exactly 1600x840. Not for writing post body content or picking which post to cover.
+---
+
+# blog-cover-generator
+
+Builds a `cover.jpg` that matches the site's existing cover convention: a
+diagonal gradient background, the post title centered in bold white type, a
+row of colored icon badges for the post's tech stack, and a footer bar with
+the site domain and social handle. No stock photos, no AI-generated art —
+it's a rendered HTML/CSS composite, same as the rest of the blog's covers.
+
+## Before building
+
+Look at 2-3 recent `public/blog-assets/*/cover.jpg` files to catch drift in
+the convention (colors already in heavy rotation, footer wording, badge
+count). Pay attention to which gradient colors the last few posts used —
+pick something that doesn't repeat the immediately preceding post.
+
+## Template structure
+
+Fixed 1600x840 canvas, four layers:
+
+1. **Background** — `linear-gradient(135deg, <dark> 0%, <mid> 45%, <accent> 100%)`.
+   Pick colors that fit the post's topic (e.g. AWS-orange-adjacent for infra
+   posts, cooler teal/indigo for AI posts) but keep the dark-to-mid-to-accent
+   diagonal structure.
+2. **Title** — centered, bold (weight 800), ~54px, white, `line-height: 1.28`,
+   positioned around `top: 190px`. Use the post's exact frontmatter `title`
+   (including any colon subtitle), manually wrapped with `<br>` into 2-4
+   roughly balanced lines (~20-30 characters per line).
+3. **Icon badges** — a centered flex row around `top: 520px`, 80x80px rounded
+   squares (`border-radius: 14px`), one per core technology in the post,
+   3-5 badges total. See the icon library below.
+4. **Footer** — bottom bar (`bottom: 40px`, `left/right: 60px`), globe icon +
+   `harun.dev` bottom-left, X/LinkedIn/Facebook glyphs + `@HarunRRayhan`
+   bottom-right. **Always `harun.dev`** — the old `blog.harun.dev` subdomain
+   now redirects to it, so never use it in a new cover.
+
+## Icon library (color + glyph conventions observed on the site)
+
+Reuse these when the post covers the same technology, so badges stay
+recognizable across posts:
+
+- **AWS Lambda** — orange `#ec7211` square, white bold serif `&lambda;` (λ)
+  character rendered as text, not a hand-drawn path (a symmetric triangle
+  reads as a Latin "A", not lambda).
+- **Amazon Bedrock** — magenta `#e5197f` square, a node/circuit SVG (4 outer
+  circles connected by lines to a center circle) — distinct from a generic
+  "AI" glyph.
+- **Fastify** — near-black `#111111` square, a bolt/lightning SVG path.
+- **Validation / security-check** — emerald `#0f9d78` square, a shield
+  outline with a checkmark inside.
+- **General "AI"** — teal/green square, a brain-or-circuit glyph (keep it
+  visually distinct from the Bedrock node icon).
+- **Terraform** — purple square, the Terraform "T" mark or a stacked-layers
+  glyph.
+- **IAM / lock-down** — darker purple or near-black square, a padlock glyph.
+- **S3** — green square, a bucket glyph.
+- **DynamoDB** — indigo/blue square, a stacked-disks glyph.
+
+For any technology not in this list, design a new simple line-art SVG
+(stroke-width 2.2-2.8, white stroke or fill, viewBox 40-44) in a color not
+already used by the other badges in the same cover, and add it to this list
+so later covers stay consistent.
+
+Reference implementation of the badge markup (Lambda + Bedrock shown, same
+pattern for the rest):
+
+```html
+<div class="badge" style="background:#ec7211;">
+  <span style="font-size:46px; font-weight:700; color:#fff; font-family: Georgia, 'Times New Roman', serif;">&lambda;</span>
+</div>
+<div class="badge" style="background:#e5197f;">
+  <svg width="44" height="44" viewBox="0 0 44 44" fill="none">
+    <circle cx="10" cy="10" r="3.4" stroke="#fff" stroke-width="2.4"/>
+    <circle cx="34" cy="10" r="3.4" stroke="#fff" stroke-width="2.4"/>
+    <circle cx="10" cy="34" r="3.4" stroke="#fff" stroke-width="2.4"/>
+    <circle cx="34" cy="34" r="3.4" stroke="#fff" stroke-width="2.4"/>
+    <circle cx="22" cy="22" r="4.2" stroke="#fff" stroke-width="2.4"/>
+    <line x1="12.8" y1="11.6" x2="19" y2="19" stroke="#fff" stroke-width="2.2"/>
+    <line x1="31.2" y1="11.6" x2="25" y2="19" stroke="#fff" stroke-width="2.2"/>
+    <line x1="12.8" y1="32.4" x2="19" y2="25" stroke="#fff" stroke-width="2.2"/>
+    <line x1="31.2" y1="32.4" x2="25" y2="25" stroke="#fff" stroke-width="2.2"/>
+  </svg>
+</div>
+```
+
+Full working template (background, title, badges, footer) is at
+`references/cover-template.html` in this skill directory — copy it, swap the
+gradient/title/badges, keep the footer as-is.
+
+## Render process
+
+Playwright's `browser_navigate` blocks `file://` URLs, and its screenshot
+tool only writes inside the repo (`.playwright-mcp/` or repo root) — so the
+render has to go through a local HTTP server:
+
+1. Write the filled-in template to a scratch `.html` file.
+2. Serve its directory: `python3 -m http.server <port> &` (background it,
+   pick a free port, run it from the scratch dir so the URL is just
+   `cover-template.html`).
+3. Load the deferred Playwright tools if not already available:
+   `ToolSearch("select:mcp__plugin_playwright_playwright__browser_navigate,mcp__plugin_playwright_playwright__browser_resize,mcp__plugin_playwright_playwright__browser_take_screenshot")`.
+4. `browser_resize` to exactly `1600x840`.
+5. `browser_navigate` to `http://127.0.0.1:<port>/cover-template.html`.
+6. `browser_take_screenshot` with `type: "jpeg"`, `scale: "css"`,
+   `fullPage: false`, saved to `.playwright-mcp/cover-render.jpg` (must be
+   inside the tool's allowed roots — repo root or `.playwright-mcp/`).
+7. Confirm the output is exactly 1600x840 with `file cover-render.jpg`.
+8. Copy it to `public/blog-assets/{slug}/cover.jpg`, overwriting whatever's
+   there.
+9. Kill the local HTTP server and delete the scratch `.html` and rendered
+   `.jpg` from wherever they landed outside the final destination — check
+   `git status --short` before committing to make sure nothing stray (like a
+   screenshot left at the repo root) got added.
+
+## What this skill doesn't do
+
+- Doesn't touch the post's markdown/frontmatter beyond confirming the title
+  and `coverImageUrl` path it needs.
+- Doesn't commit, branch, PR, or deploy — that's a separate step.
+- Doesn't source or embed real photos. If a post genuinely needs a photo
+  background (rare — only 2-3 older covers do this), that's a different
+  convention; ask before deviating from the gradient template.

--- a/.claude/skills/blog-cover-generator/references/cover-template.html
+++ b/.claude/skills/blog-cover-generator/references/cover-template.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  html, body {
+    margin: 0; padding: 0; width: 1600px; height: 840px; overflow: hidden;
+  }
+  .cover {
+    width: 1600px; height: 840px; position: relative;
+    /* swap these three gradient stops per post; keep the 135deg dark->mid->accent shape */
+    background: linear-gradient(135deg, #071a2b 0%, #0b3a44 45%, #0f8f7e 100%);
+    font-family: -apple-system, "Helvetica Neue", Arial, sans-serif;
+  }
+  .title {
+    position: absolute; top: 190px; left: 0; right: 0;
+    text-align: center; color: #ffffff; font-weight: 800;
+    font-size: 54px; line-height: 1.28; letter-spacing: -0.5px;
+  }
+  .icons {
+    position: absolute; top: 520px; left: 0; right: 0;
+    display: flex; justify-content: center; gap: 20px;
+  }
+  .badge {
+    width: 80px; height: 80px; border-radius: 14px;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .footer {
+    position: absolute; bottom: 40px; left: 60px; right: 60px;
+    display: flex; justify-content: space-between; align-items: center;
+    color: #ffffff; font-weight: 700; font-size: 20px;
+  }
+  .footer-left, .footer-right { display: flex; align-items: center; gap: 10px; }
+  .social { display: flex; align-items: center; gap: 6px; margin-right: 4px; }
+  .social span {
+    width: 22px; height: 22px; border-radius: 4px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700;
+  }
+</style>
+</head>
+<body>
+  <!-- Replace the title text and badge list below per post. Keep the footer as-is. -->
+  <div class="cover">
+    <div class="title">Replace With The<br>Post Title, Wrapped<br>Into 2-4 Lines</div>
+
+    <div class="icons">
+      <!-- Example badges: AWS Lambda + Amazon Bedrock. See SKILL.md's icon library for more. -->
+      <div class="badge" style="background:#ec7211;">
+        <span style="font-size:46px; font-weight:700; color:#fff; font-family: Georgia, 'Times New Roman', serif;">&lambda;</span>
+      </div>
+      <div class="badge" style="background:#e5197f;">
+        <svg width="44" height="44" viewBox="0 0 44 44" fill="none">
+          <circle cx="10" cy="10" r="3.4" stroke="#fff" stroke-width="2.4"/>
+          <circle cx="34" cy="10" r="3.4" stroke="#fff" stroke-width="2.4"/>
+          <circle cx="10" cy="34" r="3.4" stroke="#fff" stroke-width="2.4"/>
+          <circle cx="34" cy="34" r="3.4" stroke="#fff" stroke-width="2.4"/>
+          <circle cx="22" cy="22" r="4.2" stroke="#fff" stroke-width="2.4"/>
+          <line x1="12.8" y1="11.6" x2="19" y2="19" stroke="#fff" stroke-width="2.2"/>
+          <line x1="31.2" y1="11.6" x2="25" y2="19" stroke="#fff" stroke-width="2.2"/>
+          <line x1="12.8" y1="32.4" x2="19" y2="25" stroke="#fff" stroke-width="2.2"/>
+          <line x1="31.2" y1="32.4" x2="25" y2="25" stroke="#fff" stroke-width="2.2"/>
+        </svg>
+      </div>
+      <div class="badge" style="background:#111111;">
+        <svg width="40" height="40" viewBox="0 0 40 40" fill="none"><path d="M22 4 L10 22 H18 L16 36 L30 16 H21 Z" fill="#fff"/></svg>
+      </div>
+      <div class="badge" style="background:#0f9d78;">
+        <svg width="42" height="42" viewBox="0 0 42 42" fill="none">
+          <path d="M21 5 L34 10 V20 C34 29 28.5 34.5 21 37 C13.5 34.5 8 29 8 20 V10 Z" stroke="#fff" stroke-width="2.6" stroke-linejoin="round" fill="none"/>
+          <path d="M14.5 20.5 L19 25 L28 15" stroke="#fff" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+        </svg>
+      </div>
+    </div>
+
+    <div class="footer">
+      <div class="footer-left">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.6"><circle cx="12" cy="12" r="10"/><ellipse cx="12" cy="12" rx="4.2" ry="10"/><line x1="2" y1="12" x2="22" y2="12"/></svg>
+        <span>harun.dev</span>
+      </div>
+      <div class="footer-right">
+        <span class="social">
+          <span style="background:transparent; color:#fff; font-size:16px;">𝕏</span>
+          <span style="background:#0a66c2;">in</span>
+          <span style="background:#1877f2;">f</span>
+        </span>
+        <span>@HarunRRayhan</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Packages the cover template (gradient background, title, tech icon badges, footer) built for the AI endpoints post into a reusable `blog-cover-generator` skill and `blog-cover-artist` subagent
- Points `blog-writer`'s step 7 at the new subagent instead of just noting the cover is missing

## Test plan
- [x] Files reviewed for structure consistency with existing `.claude/agents/*.md`
- No app code touched; nothing to deploy or test in the browser

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized workflow for creating blog post cover images.
  * Covers now follow a consistent branded layout with gradients, titles, icons, badges, and footer details.
  * Generated covers use a fixed 1600×840 format for reliable display.

* **Documentation**
  * Added guidance for selecting post metadata, generating covers, and verifying image output.
  * Updated blog-writing guidance to identify when a cover image is still needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->