### PR TITLE
Fix mobile overflow on about and services pages

### DIFF
--- a/resources/js/Components/JourneyTimeline.tsx
+++ b/resources/js/Components/JourneyTimeline.tsx
@@ -56,7 +56,33 @@ export function JourneyTimeline() {
         >
           My Professional Journey
         </motion.h2>
-        <div className="relative">
+        {/* Mobile: stacked list */}
+        <div className="space-y-8 lg:hidden">
+          {timelineEvents.map((event, index) => (
+            <motion.div
+              key={index}
+              className="flex items-start gap-4"
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.8, delay: index * 0.1 }}
+            >
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-slate-700 to-slate-800">
+                <event.icon className="h-6 w-6 text-white" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <span className="text-sm font-bold text-amber-600">{event.year}</span>
+                <h3 className="mb-1 text-lg font-semibold text-gray-900">{event.title}</h3>
+                <p className="mb-1 font-medium text-amber-600">{event.company}</p>
+                <p className="mb-2 text-sm text-gray-500">{event.location}</p>
+                <p className="text-sm text-gray-600">{event.description}</p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Desktop: alternating timeline */}
+        <div className="relative hidden lg:block">
           {/* Vertical line */}
           <div className="absolute left-1/2 transform -translate-x-1/2 w-1 h-full bg-gradient-to-b from-slate-700 via-slate-800 to-slate-900"></div>
 

--- a/resources/js/Components/VolunteeringSection.tsx
+++ b/resources/js/Components/VolunteeringSection.tsx
@@ -28,16 +28,16 @@ export function VolunteeringSection() {
             viewport={{ once: true }}
             transition={{ duration: 0.8 }}
           >
-            <div className="rounded-xl border bg-gradient-to-br from-amber-500/5 to-amber-600/5 shadow p-8">
-              <div className="flex items-start gap-8">
-                <div className="w-32 h-32 rounded-lg flex items-center justify-center flex-shrink-0">
+            <div className="rounded-xl border bg-gradient-to-br from-amber-500/5 to-amber-600/5 shadow p-5 sm:p-8">
+              <div className="flex flex-col items-start gap-6 sm:flex-row sm:gap-8">
+                <div className="w-32 h-32 rounded-lg flex items-center justify-center flex-shrink-0 mx-auto sm:mx-0">
                   <img
                     src={getImageUrl("/images/community/aws-community-builder.png")}
                     alt="AWS Community Builder"
                     className="w-32 h-32 object-contain"
                   />
                 </div>
-                <div className="flex-1">
+                <div className="min-w-0 flex-1">
                   <h3 className="text-3xl font-bold text-gray-900 mb-3">AWS Community Builder</h3>
                   <p className="text-amber-600 font-medium text-lg mb-2">Amazon Web Services (AWS)</p>
                   <p className="text-gray-600 text-lg mb-4">Mar 2022 - Present</p>

--- a/resources/js/Pages/Services.tsx
+++ b/resources/js/Pages/Services.tsx
@@ -254,9 +254,9 @@ export default function ServicesPage() {
                                 <Button
                                     variant="outline"
                                     size="lg"
-                                    className="bg-white text-slate-700 hover:bg-slate-900 hover:text-white border-slate-300 transition-all duration-300"
+                                    className="h-auto w-full max-w-xl whitespace-normal bg-white py-3 text-center text-slate-700 transition-all duration-300 hover:bg-slate-900 hover:text-white border-slate-300"
                                 >
-                                    <MessageSquare className="w-5 h-5 mr-2"/>
+                                    <MessageSquare className="w-5 h-5 mr-2 shrink-0"/>
                                     Is the service you're looking for missing? We might do it. Send us a message.
                                 </Button>
                             </Link>


### PR DESCRIPTION
## Summary
- Timeline on `/about` now renders a stacked mobile layout instead of the desktop alternating zig-zag, which structurally couldn't fit a 375px viewport
- AWS Community Builder card on `/about` stacks image above text on mobile with `min-w-0` so the text column shrinks properly
- Services page CTA button wraps its text instead of forcing one unbreakable line off-screen

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Verified `overflow: 0` at 375px width on `/about` and `/services` via Playwright
- [x] Screenshot-confirmed both fixed sections render cleanly on mobile
- [ ] Live production visual check (blocked — Lightsail server outage from a separate ongoing issue)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile-friendly journey timeline with stacked event cards, icons, and animated transitions.
* **Style**
  * Improved the volunteering section’s responsive layout, spacing, and image alignment across screen sizes.
  * Updated the services contact button with improved sizing, text wrapping, hover states, borders, and icon alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->