### PR TITLE
Fix broken frontmatter delimiter on AI endpoints post

### DIFF
--- a/resources/blog/posts/ai-endpoints-post-generate-validation-lambda-bedrock-fastify.md
+++ b/resources/blog/posts/ai-endpoints-post-generate-validation-lambda-bedrock-fastify.md
@@ -20,7 +20,8 @@ tags:
   - name: AI
     slug: ai
   - name: Serverless
-    slug: serverless---
+    slug: serverless
+---
 
 <p>I shipped a refund of $180 twice last quarter, to the same customer, from an endpoint that had passed every test I wrote for it. The endpoint was a Fastify route running on Lambda. It took a support email, asked Claude on Bedrock to pull out the intent and a refund amount, and if the intent came back as "refund" it dropped a job on an SQS queue. Textbook serverless AI. It worked in the demo, it worked in staging, and then a real email came in that the model read a little too generously.</p>
 <p>Claude returned valid JSON. That was the problem. The shape was perfect, the <code>refund_amount_cents</code> field was a clean integer, and the value was four times the order total because the customer had listed three past orders in the same thread. My handler trusted the shape, enqueued the job, the invoke timed out on the client side, the client retried, and my handler happily enqueued a second identical job. Two refunds, one CloudWatch log I found the next morning.</p>


### PR DESCRIPTION
## Summary
- One blog post's YAML frontmatter had its closing `---` glued onto the last tag's `slug` line with no newline, which broke `BlogRepository`'s frontmatter regex
- Since posts are loaded and cached in one batch, the parse failure on this single file threw a 500 for the entire `/blog` index, not just this post

## Test plan
- [x] Reproduced the 500 locally, confirmed via `storage/logs/laravel.log`
- [x] Fixed the line break, cleared cache, verified `/blog` and the individual post both load with no errors

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE