### PR TITLE
Use the new brand mark for the Portfolio link on the bio page

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -146,6 +146,7 @@ const PRODUCT_LOGOS: Record<string, string> = {
   'https://crontinel.com': '/images/products/crontinel.png',
   'https://appnary.com': '/images/products/appnary-icon.png',
   'https://amazingplugins.com': '/images/products/amazingplugins.jpg',
+  'https://harun.dev': '/favicon.svg',
 }
 
 /** Standard-row icon: a product's real logo when it has one, otherwise the


### PR DESCRIPTION
## Summary
- The Products tab's last link (Portfolio → harun.dev) had no entry in `PRODUCT_LOGOS`, so it fell back to Google's favicon service, which still serves the pre-redesign favicon.
- Points it at `public/favicon.svg`, which already matches the new circuit-trace H mark shipped in #89.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Verified locally via Playwright: `/bio` → Products tab → Portfolio row now renders the new logo mark

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE