### PR TITLE
Add Vibe Scaler and Vibe Code Migration services

### DIFF
--- a/resources/js/Pages/Services.tsx
+++ b/resources/js/Pages/Services.tsx
@@ -20,10 +20,26 @@ import {
     MonitorSmartphone,
     MessageSquare,
     Grid,
+    Gauge,
+    Replace,
 } from "lucide-react"
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger} from "@/Components/ui/accordion"
 
 const services = [
+    {
+        icon: Gauge,
+        title: "Vibe Scaler",
+        description:
+            "We take an app you built fast with AI coding tools and scale it in place to handle real traffic and payments.",
+        link: "/services/vibe-scaling",
+    },
+    {
+        icon: Replace,
+        title: "Vibe Code Migration",
+        description:
+            "We port an app you built fast with AI coding tools to a production language and framework, feature for feature, without losing data or users.",
+        link: "/services/vibe-code-migration",
+    },
     {
         icon: Cloud,
         title: "Multi-Cloud Architecture",

--- a/resources/js/Pages/Services/VibeCodeMigration.tsx
+++ b/resources/js/Pages/Services/VibeCodeMigration.tsx
@@ -1,0 +1,353 @@
+'use client'
+
+import { ServiceHero } from "@/Components/ServiceHero"
+import { Button } from "@/Components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"
+import { Replace, Layers, Database, ArrowRight, CheckCircle, Search, ClipboardList, Code, Rocket } from 'lucide-react'
+import { Link, Head } from '@inertiajs/react'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/Components/ui/accordion"
+import { motion } from "framer-motion"
+import { InfiniteScrollTech } from "@/Components/InfiniteScrollTech"
+import { getImageUrl } from "@/lib/imageUtils"
+
+const technologies = [
+  {
+    name: "Node.js",
+    logo: getImageUrl("/images/tech/nodejs.svg"),
+  },
+  {
+    name: "Python",
+    logo: getImageUrl("/images/tech/python.svg"),
+  },
+  {
+    name: "Laravel",
+    logo: getImageUrl("/images/tech/laravel.svg"),
+  },
+  {
+    name: "Go",
+    logo: getImageUrl("/images/tech/go.svg"),
+  },
+  {
+    name: "React",
+    logo: getImageUrl("/images/tech/react.svg"),
+  },
+  {
+    name: "PostgreSQL",
+    logo: getImageUrl("/images/logos/db/postgresql-logo.png"),
+  },
+  {
+    name: "Redis",
+    logo: getImageUrl("/images/logos/performance/redis-logo.png"),
+  },
+  {
+    name: "Docker",
+    logo: getImageUrl("/images/tech/docker.svg"),
+  },
+  {
+    name: "Kubernetes",
+    logo: getImageUrl("/images/tech/kubernetes.svg"),
+  },
+  {
+    name: "AWS",
+    logo: getImageUrl("/images/tech/aws.svg"),
+  },
+  {
+    name: "GitHub Actions",
+    logo: getImageUrl("/images/tech/github-actions.svg"),
+  },
+  {
+    name: "Terraform",
+    logo: getImageUrl("/images/tech/terraform.svg"),
+  },
+]
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.6 },
+}
+
+const staggerChildren = {
+  animate: { transition: { staggerChildren: 0.1 } },
+}
+
+export default function VibeCodeMigration() {
+  return (
+    <>
+      <Head>
+        <title>Vibe Code Migration: Port Your AI-Built App to a Production Stack | Harun R. Rayhan</title>
+        <meta name="description" content="Your prototype found real users, but the stack it started on cannot be its permanent home. We port it to a production language and framework, feature for feature, without losing data or the users you already have." />
+        <meta name="keywords" content="migrate vibe coded app, port prototype to production, Cursor app migration, Lovable app port, no-code to production code, framework migration, feature parity testing, gradual cutover" />
+
+        {/* OpenGraph Tags */}
+        <meta property="og:title" content="Vibe Code Migration: Port Your AI-Built App to a Production Stack | Harun R. Rayhan" />
+        <meta property="og:description" content="Your prototype found real users, but the stack it started on cannot be its permanent home. We port it to a production language and framework, feature for feature, without losing data or the users you already have." />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={window.location.href} />
+
+        {/* Twitter Card Tags */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Vibe Code Migration: Port Your AI-Built App to a Production Stack | Harun R. Rayhan" />
+        <meta name="twitter:description" content="Your prototype found real users, but the stack it started on cannot be its permanent home. We port it to a production language and framework, feature for feature, without losing data or the users you already have." />
+
+        {/* Canonical URL */}
+        <link rel="canonical" href={window.location.href} />
+
+        {/* JSON-LD Structured Data */}
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Service",
+            "name": "Vibe Code Migration",
+            "provider": {
+              "@type": "Person",
+              "name": "Harun R. Rayhan",
+              "description": "Software Scaling and Performance Expert"
+            },
+            "serviceType": "Application Migration Services",
+            "description": "Porting apps first built with AI coding tools to a production language and framework, with feature parity and no data loss",
+            "offers": {
+              "@type": "Offer",
+              "description": "Production Rebuild With Parity, A Production Foundation, Data Migration"
+            },
+            "hasOfferCatalog": {
+              "@type": "OfferCatalog",
+              "name": "Vibe Code Migration Services",
+              "itemListElement": [
+                {
+                  "@type": "Offer",
+                  "itemOffered": {
+                    "@type": "Service",
+                    "name": "Production Rebuild With Parity",
+                    "description": "Rebuilding the app on a new language and framework with identical behavior, verified against the original with parity tests"
+                  }
+                },
+                {
+                  "@type": "Offer",
+                  "itemOffered": {
+                    "@type": "Service",
+                    "name": "A Production Foundation",
+                    "description": "A typed codebase, real migrations, a test suite, and a deploy pipeline the team can keep extending"
+                  }
+                },
+                {
+                  "@type": "Offer",
+                  "itemOffered": {
+                    "@type": "Service",
+                    "name": "Data Migration",
+                    "description": "Moving users, records, and history to the new schema in stages, with row counts and key records verified on both sides"
+                  }
+                }
+              ]
+            }
+          })}
+        </script>
+      </Head>
+      <main className="flex flex-col min-h-screen">
+        <ServiceHero
+          icon={Replace}
+          title="Vibe Code Migration"
+          description="Your prototype did its job and found real users. When the stack it started on cannot carry it any further, we move it to a production language and framework and keep every feature working."
+        />
+        <div className="container mx-auto px-4 py-4">
+          <Link href="/services" className="inline-flex items-center text-amber-600 hover:text-amber-700 font-medium">
+            <ArrowRight className="w-4 h-4 mr-2 rotate-180" />
+            Back to Services
+          </Link>
+        </div>
+        <motion.section className="py-24 bg-white" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4">
+            <motion.h2 className="text-3xl font-bold text-center mb-12" variants={fadeInUp}>
+              What We Do
+            </motion.h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+              {[
+                {
+                  icon: Replace,
+                  title: "A Rebuild That Matches",
+                  content:
+                    "We port your app to a new language and framework and keep the behavior identical. Every screen, rule, and edge case comes across the same way, checked against the original with parity tests so nothing quietly changes.",
+                },
+                {
+                  icon: Layers,
+                  title: "A Production Foundation",
+                  content:
+                    "The new build sits on a language and framework meant to run for years, with typed code, real migrations, a test suite, and a deploy pipeline. It is a base your team can keep extending long after the move is done.",
+                },
+                {
+                  icon: Database,
+                  title: "Your Data Comes With It",
+                  content:
+                    "Users, records, and history move over intact. We map the old schema to the new one, migrate the data in stages, and verify row counts and key records on both sides before anything goes live.",
+                },
+              ].map((service, index) => (
+                <motion.div key={index} variants={fadeInUp}>
+                  <Card>
+                    <CardHeader>
+                      <service.icon className="w-10 h-10 text-amber-600 mb-4" />
+                      <CardTitle>{service.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent>{service.content}</CardContent>
+                  </Card>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="py-24 bg-gray-50" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4">
+            <motion.h2 className="text-3xl font-bold text-center mb-12" variants={fadeInUp}>
+              Why Work With Us
+            </motion.h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+              {[
+                {
+                  title: "We respect what you built",
+                  content:
+                    "The prototype found users and proved the idea. That is the hard part, and vibe coding is a smart way to get there. Our job is the move to a stack that lasts, not second-guessing how you started.",
+                },
+                {
+                  title: "We keep parity front and center",
+                  content:
+                    "A migration is only done when the new app does everything the old one did. We write tests against the current behavior first, then port until every one of them passes, so features do not go missing in the move.",
+                },
+                {
+                  title: "We have done this on harder systems",
+                  content:
+                    "We have ported production systems a lot more involved than a weekend project, including business software running on older frameworks. The care that protects a system that size protects yours.",
+                },
+                {
+                  title: "We hand it back to you",
+                  content:
+                    "When the move is done we walk your team through the new stack and how it is put together. You are left with an app you can run and extend, not a dependency on us.",
+                },
+              ].map((item, index) => (
+                <motion.div key={index} className="flex items-start space-x-4" variants={fadeInUp}>
+                  <CheckCircle className="w-6 h-6 text-amber-600 flex-shrink-0 mt-1" />
+                  <div>
+                    <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
+                    <p>{item.content}</p>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="py-24 bg-white" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4">
+            <motion.h2 className="text-3xl font-bold text-center mb-12" variants={fadeInUp}>
+              How It Works
+            </motion.h2>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+              {[
+                {
+                  icon: Search,
+                  title: "1. Map",
+                  content:
+                    "We go through the current app and write down what it does: every feature, rule, and integration. That map becomes the checklist the new build has to satisfy.",
+                },
+                {
+                  icon: ClipboardList,
+                  title: "2. Plan",
+                  content:
+                    "We pick the target language and framework that fit where the product is going, then lay out the order of work and how the data will move, before writing new code.",
+                },
+                {
+                  icon: Code,
+                  title: "3. Port",
+                  content:
+                    "We rebuild the app on the new stack feature by feature, checking each one against the original with parity tests. Work ships in pieces so progress stays visible.",
+                },
+                {
+                  icon: Rocket,
+                  title: "4. Cut Over",
+                  content:
+                    "We run the new app alongside the old one, move traffic across gradually, and keep the old version ready as a fallback until the new one has proven itself in production.",
+                },
+              ].map((step, index) => (
+                <motion.div key={index} variants={fadeInUp}>
+                  <Card>
+                    <CardHeader>
+                      <step.icon className="w-10 h-10 text-amber-600 mb-4" />
+                      <CardTitle>{step.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent>{step.content}</CardContent>
+                  </Card>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <InfiniteScrollTech technologies={technologies} backgroundColor="#F8F9FA" />
+
+        <motion.section className="py-24 bg-white" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4 text-center">
+            <motion.h2 className="text-3xl font-bold mb-8" variants={fadeInUp}>
+              Ready to move to a stack that lasts?
+            </motion.h2>
+            <motion.div variants={fadeInUp}>
+              <Link href="/contact">
+                <Button size="lg" className="bg-slate-900 hover:bg-slate-800 text-white">
+                  Get Started
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Button>
+              </Link>
+            </motion.div>
+          </div>
+        </motion.section>
+
+        <motion.section className="py-24 bg-gray-50" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4">
+            <motion.h2 className="text-3xl font-bold text-center mb-12" variants={fadeInUp}>
+              Frequently Asked Questions
+            </motion.h2>
+            <motion.div variants={fadeInUp}>
+              <Accordion type="single" collapsible className="max-w-3xl mx-auto">
+                {[
+                  {
+                    question: "Does migrating mean my prototype was a mistake?",
+                    answer:
+                      "No. Building fast with AI coding tools is a smart way to get a real product in front of people, and it worked. A prototype stack is meant to prove an idea, not run forever. Moving to a production language and framework is the next step after that, not a fix for a wrong first one.",
+                  },
+                  {
+                    question: "Will we lose any data or features in the migration?",
+                    answer:
+                      "No. Keeping everything is the whole reason to do it carefully. We write down every feature in the current app and turn it into a checklist the new build has to pass. Data moves over in stages with row counts and key records verified on both sides. If something does not match, it does not ship.",
+                  },
+                  {
+                    question: "Why not just keep scaling the current stack instead of moving?",
+                    answer:
+                      "Often that is the right call, and it is a separate service we offer called Vibe Scaler. Scaling in place works when the stack is sound and only its config and slow paths need attention. Migration is for when the stack itself is the ceiling, where the language or framework cannot get you where the product is going no matter how much you tune it. We will tell you honestly which case you are in before you spend anything.",
+                  },
+                  {
+                    question: "How do you handle cutover and downtime?",
+                    answer:
+                      "We run the new app next to the old one rather than flipping a switch. Traffic moves across in stages, starting small, and we watch each step. The old version stays ready the whole time, so if anything looks wrong we route back to it in seconds while we sort it out.",
+                  },
+                  {
+                    question: "What languages and frameworks do you migrate to?",
+                    answer:
+                      "Whatever fits where your product is heading. In practice that is often a typed backend on Node, Python, Go, or PHP with a framework like Laravel, a React front end, and PostgreSQL behind it. We pick the target for the next few years of the product, not just the next release.",
+                  },
+                  {
+                    question: "How long does a migration take?",
+                    answer:
+                      "It depends on how much the app does, which is why the first step is mapping every feature. A small app can move in a few weeks. A larger one ships in stages, with parts running on the new stack while the rest still runs on the old one, so you are never waiting on one big release.",
+                  },
+                ].map((faq, index) => (
+                  <AccordionItem key={index} value={`item-${index + 1}`}>
+                    <AccordionTrigger className="text-left">{faq.question}</AccordionTrigger>
+                    <AccordionContent>{faq.answer}</AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </motion.div>
+          </div>
+        </motion.section>
+      </main>
+    </>
+  )
+}

--- a/resources/js/Pages/Services/VibeScaling.tsx
+++ b/resources/js/Pages/Services/VibeScaling.tsx
@@ -1,0 +1,353 @@
+'use client'
+
+import { ServiceHero } from "@/Components/ServiceHero"
+import { Button } from "@/Components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"
+import { Gauge, Zap, Database, Activity, ArrowRight, CheckCircle, Search, ClipboardList, Wrench, LineChart } from 'lucide-react'
+import { Link, Head } from '@inertiajs/react'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/Components/ui/accordion"
+import { motion } from "framer-motion"
+import { InfiniteScrollTech } from "@/Components/InfiniteScrollTech"
+import { getImageUrl } from "@/lib/imageUtils"
+
+const technologies = [
+  {
+    name: "PostgreSQL",
+    logo: getImageUrl("/images/logos/db/postgresql-logo.png"),
+  },
+  {
+    name: "MySQL",
+    logo: getImageUrl("/images/logos/db/mysql-logo.png"),
+  },
+  {
+    name: "Redis",
+    logo: getImageUrl("/images/logos/performance/redis-logo.png"),
+  },
+  {
+    name: "Docker",
+    logo: getImageUrl("/images/logos/tech/vertical-logo-monochromatic.png"),
+  },
+  {
+    name: "Kubernetes",
+    logo: getImageUrl("/images/logos/tech/Kubernetes_logo_without_workmark.svg"),
+  },
+  {
+    name: "AWS",
+    logo: getImageUrl("/images/logos/tech/Amazon_Web_Services_Logo.svg"),
+  },
+  {
+    name: "Terraform",
+    logo: getImageUrl("/images/logos/tech/terraformio-icon.svg"),
+  },
+  {
+    name: "Prometheus",
+    logo: getImageUrl("/images/logos/tech/Prometheus_software_logo.svg"),
+  },
+  {
+    name: "Grafana",
+    logo: getImageUrl("/images/logos/tech/Grafana_icon.svg"),
+  },
+  {
+    name: "Datadog",
+    logo: getImageUrl("/images/logos/performance/datadog-logo.png"),
+  },
+  {
+    name: "New Relic",
+    logo: getImageUrl("/images/logos/performance/new-relic-logo.svg"),
+  },
+  {
+    name: "Elasticsearch",
+    logo: getImageUrl("/images/logos/logo-elastic-outlined-black.svg"),
+  },
+]
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.6 },
+}
+
+const staggerChildren = {
+  animate: { transition: { staggerChildren: 0.1 } },
+}
+
+export default function VibeScaling() {
+  return (
+    <>
+      <Head>
+        <title>Vibe Scaler: Scale Your AI-Built App | Harun R. Rayhan</title>
+        <meta name="description" content="You built your app fast with AI coding tools and it found real users. We scale it in place: performance under load, database fixes, monitoring, and reliability, no rewrite required." />
+        <meta name="keywords" content="scale vibe coded app, AI built app scaling, Cursor app scaling, Lovable app performance, Replit app production, database bottleneck fix, app performance consulting, scale in place" />
+
+        {/* OpenGraph Tags */}
+        <meta property="og:title" content="Vibe Scaler: Scale Your AI-Built App | Harun R. Rayhan" />
+        <meta property="og:description" content="You built your app fast with AI coding tools and it found real users. We scale it in place: performance under load, database fixes, monitoring, and reliability, no rewrite required." />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={window.location.href} />
+
+        {/* Twitter Card Tags */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Vibe Scaler: Scale Your AI-Built App | Harun R. Rayhan" />
+        <meta name="twitter:description" content="You built your app fast with AI coding tools and it found real users. We scale it in place: performance under load, database fixes, monitoring, and reliability, no rewrite required." />
+
+        {/* Canonical URL */}
+        <link rel="canonical" href={window.location.href} />
+
+        {/* JSON-LD Structured Data */}
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Service",
+            "name": "Vibe Scaler",
+            "provider": {
+              "@type": "Person",
+              "name": "Harun R. Rayhan",
+              "description": "Software Scaling and Performance Expert"
+            },
+            "serviceType": "Application Scaling Services",
+            "description": "Scaling and hardening services for apps first built with AI coding tools, done in place without a rewrite",
+            "offers": {
+              "@type": "Offer",
+              "description": "Performance Under Load, Database Hardening, Reliability and Monitoring"
+            },
+            "hasOfferCatalog": {
+              "@type": "OfferCatalog",
+              "name": "Vibe Scaler Services",
+              "itemListElement": [
+                {
+                  "@type": "Offer",
+                  "itemOffered": {
+                    "@type": "Service",
+                    "name": "Performance Under Load",
+                    "description": "Profiling under real traffic and fixing the slow paths with caching, background workers, and query fixes"
+                  }
+                },
+                {
+                  "@type": "Offer",
+                  "itemOffered": {
+                    "@type": "Service",
+                    "name": "Database Hardening",
+                    "description": "Adding missing indexes, fixing N+1 queries, and setting up connection pooling so the database keeps up as data grows"
+                  }
+                },
+                {
+                  "@type": "Offer",
+                  "itemOffered": {
+                    "@type": "Service",
+                    "name": "Reliability and Monitoring",
+                    "description": "Error tracking, uptime checks, dashboards, backups, and a way to roll back a bad deploy"
+                  }
+                }
+              ]
+            }
+          })}
+        </script>
+      </Head>
+      <main className="flex flex-col min-h-screen">
+        <ServiceHero
+          icon={Gauge}
+          title="Vibe Scaler"
+          description="You built it fast with AI coding tools and it found real users. We take that app and make it hold up under the traffic and payments now coming through it."
+        />
+        <div className="container mx-auto px-4 py-4">
+          <Link href="/services" className="inline-flex items-center text-amber-600 hover:text-amber-700 font-medium">
+            <ArrowRight className="w-4 h-4 mr-2 rotate-180" />
+            Back to Services
+          </Link>
+        </div>
+        <motion.section className="py-24 bg-white" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4">
+            <motion.h2 className="text-3xl font-bold text-center mb-12" variants={fadeInUp}>
+              What We Do
+            </motion.h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+              {[
+                {
+                  icon: Zap,
+                  title: "Performance Under Load",
+                  content:
+                    "We profile the app under real traffic and fix the slow paths. That usually means adding caching, moving heavy work into background jobs, and rewriting the queries that drag pages down, so response times stay flat as usage climbs.",
+                },
+                {
+                  icon: Database,
+                  title: "A Database That Holds Up",
+                  content:
+                    "The database is where most vibe-coded apps break first. We add the indexes that are missing, fix the N+1 queries an AI tool tends to leave behind, and set up connection pooling so it keeps up as your data grows.",
+                },
+                {
+                  icon: Activity,
+                  title: "Reliability and Monitoring",
+                  content:
+                    "We add error tracking, uptime checks, and dashboards so you find out something broke before your users do. We also set up backups and a fast way to roll back a bad deploy.",
+                },
+              ].map((service, index) => (
+                <motion.div key={index} variants={fadeInUp}>
+                  <Card>
+                    <CardHeader>
+                      <service.icon className="w-10 h-10 text-amber-600 mb-4" />
+                      <CardTitle>{service.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent>{service.content}</CardContent>
+                  </Card>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="py-24 bg-gray-50" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4">
+            <motion.h2 className="text-3xl font-bold text-center mb-12" variants={fadeInUp}>
+              Why Work With Us
+            </motion.h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+              {[
+                {
+                  title: "We respect what you built",
+                  content:
+                    "Vibe coding got you a working product and paying users. Most ideas never get that far. We treat that as the hard part being done, and our job is the next part, not second-guessing the first.",
+                },
+                {
+                  title: "We fix the stack you already have",
+                  content:
+                    "This is scaling in place. We work with the code, framework, and hosting you already run instead of starting over, so you keep shipping to customers while we harden it underneath you.",
+                },
+                {
+                  title: "We measure before we change anything",
+                  content:
+                    "We do not guess at what is slow. We run the app under load that matches your real traffic, find the actual bottlenecks, and fix those first so the work buys you the most headroom.",
+                },
+                {
+                  title: "We hand it back to you",
+                  content:
+                    "When we are done we walk your team through what changed and how to keep it running. You are left with an app you can operate, not a dependency on us.",
+                },
+              ].map((item, index) => (
+                <motion.div key={index} className="flex items-start space-x-4" variants={fadeInUp}>
+                  <CheckCircle className="w-6 h-6 text-amber-600 flex-shrink-0 mt-1" />
+                  <div>
+                    <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
+                    <p>{item.content}</p>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="py-24 bg-white" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4">
+            <motion.h2 className="text-3xl font-bold text-center mb-12" variants={fadeInUp}>
+              How It Works
+            </motion.h2>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+              {[
+                {
+                  icon: Search,
+                  title: "1. Audit",
+                  content:
+                    "We go through your code, database, and hosting, then run the app under realistic load to see where it strains.",
+                },
+                {
+                  icon: ClipboardList,
+                  title: "2. Plan",
+                  content:
+                    "You get a short list of what is slowing the app down and what each fix takes, ordered by how much it helps.",
+                },
+                {
+                  icon: Wrench,
+                  title: "3. Harden",
+                  content:
+                    "We do the work: caching, indexes, background jobs, connection limits, and whatever else the audit turned up. It ships in small changes so nothing breaks at once.",
+                },
+                {
+                  icon: LineChart,
+                  title: "4. Monitor",
+                  content:
+                    "We set up dashboards and alerts so problems surface early, and show your team how to read them.",
+                },
+              ].map((step, index) => (
+                <motion.div key={index} variants={fadeInUp}>
+                  <Card>
+                    <CardHeader>
+                      <step.icon className="w-10 h-10 text-amber-600 mb-4" />
+                      <CardTitle>{step.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent>{step.content}</CardContent>
+                  </Card>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <InfiniteScrollTech technologies={technologies} backgroundColor="#F8F9FA" />
+
+        <motion.section className="py-24 bg-white" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4 text-center">
+            <motion.h2 className="text-3xl font-bold mb-8" variants={fadeInUp}>
+              Outgrowing the app that got you here?
+            </motion.h2>
+            <motion.div variants={fadeInUp}>
+              <Link href="/contact">
+                <Button size="lg" className="bg-slate-900 hover:bg-slate-800 text-white">
+                  Get Started
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Button>
+              </Link>
+            </motion.div>
+          </div>
+        </motion.section>
+
+        <motion.section className="py-24 bg-gray-50" initial="initial" animate="animate" variants={staggerChildren}>
+          <div className="container mx-auto px-4">
+            <motion.h2 className="text-3xl font-bold text-center mb-12" variants={fadeInUp}>
+              Frequently Asked Questions
+            </motion.h2>
+            <motion.div variants={fadeInUp}>
+              <Accordion type="single" collapsible className="max-w-3xl mx-auto">
+                {[
+                  {
+                    question: "Is there something wrong with vibe coding my app?",
+                    answer:
+                      "No. Building with AI coding tools to get a real product in front of people is a smart way to start, and it worked. You have users, and payments are coming in. That is the hard part, and most ideas never reach it. Scaling what you built is a different kind of work, and that is the part we do.",
+                  },
+                  {
+                    question: "What does scaling in place mean?",
+                    answer:
+                      "It means we improve the app you already have instead of rewriting it. We keep your language, framework, and hosting, and fix the parts that cannot keep up with your traffic. You keep running your business while we do it.",
+                  },
+                  {
+                    question: "What if my app actually needs a full rewrite?",
+                    answer:
+                      "Sometimes it does. If your stack has hit a real ceiling and no amount of tuning will get it where you need to go, we will tell you that plainly. Moving an app to a different language or framework is a separate service we offer, so you get an honest answer instead of patches that will not hold.",
+                  },
+                  {
+                    question: "How do you decide what to fix first?",
+                    answer:
+                      "We measure before we touch anything. We run your app under load that matches your real traffic, watch where it slows down or falls over, and start with the changes that buy you the most headroom for the least risk.",
+                  },
+                  {
+                    question: "Will my app go down while you work on it?",
+                    answer:
+                      "No. We ship changes in small pieces and test each one before it goes live. We also set up a fast way to roll back a deploy, so if something looks wrong after a release we can undo it in seconds.",
+                  },
+                  {
+                    question: "Which stacks do you work with?",
+                    answer:
+                      "Most apps that come out of tools like Cursor, Bolt, Lovable, Replit, and v0. In practice that means React or Next.js on the front end, a Node, Python, or PHP backend, and PostgreSQL or MySQL behind it. If you are on something else, ask us and we will tell you honestly whether we can help.",
+                  },
+                ].map((faq, index) => (
+                  <AccordionItem key={index} value={`item-${index + 1}`}>
+                    <AccordionTrigger className="text-left">{faq.question}</AccordionTrigger>
+                    <AccordionContent>{faq.answer}</AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </motion.div>
+          </div>
+        </motion.section>
+      </main>
+    </>
+  )
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -272,6 +272,14 @@ Route::get('/services/multi-cloud-architecture', function () {
     return Inertia::render('Services/MultiCloudArchitecture');
 })->name('services.multi-cloud-architecture');
 
+Route::get('/services/vibe-scaling', function () {
+    return Inertia::render('Services/VibeScaling');
+})->name('services.vibe-scaling');
+
+Route::get('/services/vibe-code-migration', function () {
+    return Inertia::render('Services/VibeCodeMigration');
+})->name('services.vibe-code-migration');
+
 Route::get('/book', function () {
     return Inertia::render('Book');
 })->name('book');


### PR DESCRIPTION
## Summary
- New `/services/vibe-scaling` page: scaling an app that started as an AI-coded prototype once it has real traffic and payments, done in place without a rewrite.
- New `/services/vibe-code-migration` page: porting a prototype to a production language/framework when the stack itself, not just its scale, is the constraint.
- Both added to the `/services` index (leading the grid) and routed in `routes/web.php`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Verified both pages and the `/services` index render correctly in local dev (Valet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Vibe Scaler” and “Vibe Code Migration” service offerings to the Services page.
  * Added dedicated landing pages for both services, including service details, technology showcases, FAQs, animations, and contact call-to-actions.
  * Added public navigation routes for accessing the new service pages.
* **Documentation**
  * Added SEO and social sharing metadata for the new service pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->