### PR TITLE
Update header tagline to DevOps, AI/ML, Cloud, and Product Engineering

### DIFF
--- a/resources/js/Components/Menubar.tsx
+++ b/resources/js/Components/Menubar.tsx
@@ -79,7 +79,7 @@ export function Menubar() {
           <Logo className="h-9 w-9" />
           <div className="hidden sm:block">
             <p className="text-sm font-semibold tracking-tight text-slate-900">Harun R. Rayhan</p>
-            <p className="text-xs text-slate-500">Cloud, DevOps, and product engineering</p>
+            <p className="text-xs text-slate-500">DevOps, AI/ML, Cloud, and Product Engineering</p>
           </div>
         </Link>
 


### PR DESCRIPTION
## Summary
- Site header tagline (shown under the name in the top nav on every page) changed from "Cloud, DevOps, and product engineering" to "DevOps, AI/ML, Cloud, and Product Engineering"

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Diff confirmed to touch only the intended string
- [ ] Spot-check header on production after deploy

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE