### PR TITLE
Fix mobile menu layout break and tighten mobile responsiveness

### DIFF
--- a/resources/js/Components/AboutHero.tsx
+++ b/resources/js/Components/AboutHero.tsx
@@ -38,7 +38,7 @@ export function AboutHero() {
             </motion.div>
           </motion.div>
           <motion.div
-            className="lg:w-1/2 flex justify-end"
+            className="flex justify-center lg:w-1/2 lg:justify-end"
             initial={{ opacity: 0, scale: 0.8 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.8 }}
@@ -47,7 +47,7 @@ export function AboutHero() {
               <img
                 src={getImageUrl("/images/profile/harun-profile.jpeg")}
                 alt="Harun R. Rayhan - Software Engineer and Cloud Architect"
-                className="w-80 h-80 rounded-full shadow-2xl border-4 border-white/20 object-cover"
+                className="h-56 w-56 rounded-full border-4 border-white/20 object-cover shadow-2xl sm:h-72 sm:w-72 lg:h-80 lg:w-80"
                 loading="eager"
               />
             </div>

--- a/resources/js/Components/HeroSectionV2.tsx
+++ b/resources/js/Components/HeroSectionV2.tsx
@@ -116,9 +116,9 @@ export function HeroSectionV2() {
                             {highlights.map((item, i) => (
                                 <div
                                     key={item.label}
-                                    className={`flex-1${i > 0 ? ' border-l border-slate-200 pl-6' : ''}${i < highlights.length - 1 ? ' pr-6' : ''}`}
+                                    className={`flex-1${i > 0 ? ' border-l border-slate-200 pl-4 sm:pl-6' : ''}${i < highlights.length - 1 ? ' pr-4 sm:pr-6' : ''}`}
                                 >
-                                    <div className="font-mono text-2xl font-semibold tabular-nums text-slate-900">
+                                    <div className="font-mono text-xl font-semibold tabular-nums text-slate-900 sm:text-2xl">
                                         {item.value}
                                     </div>
                                     <div className="mt-0.5 text-xs font-medium uppercase tracking-[0.12em] text-slate-400">

--- a/resources/js/Components/Menubar.tsx
+++ b/resources/js/Components/Menubar.tsx
@@ -5,7 +5,7 @@ import { Link, router, usePage } from '@inertiajs/react'
 import { cn } from '@/lib/utils'
 import { Logo } from './Logo'
 import { Calendar, ChevronDown, ExternalLink, LogOut, Menu, User } from 'lucide-react'
-import { Sheet, SheetContent, SheetTrigger } from '@/Components/ui/sheet'
+import { Sheet, SheetContent, SheetDescription, SheetTitle, SheetTrigger } from '@/Components/ui/sheet'
 
 const mainNavItems = [
   { name: 'Home', href: '/' },
@@ -74,7 +74,7 @@ export function Menubar() {
           : 'border-transparent bg-white/70 backdrop-blur-md',
       )}
     >
-      <div className="mx-auto grid max-w-7xl items-center gap-3 px-4 py-3 sm:px-6 lg:grid-cols-[auto_minmax(0,1fr)_auto] lg:px-8">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-4 py-3 sm:px-6 lg:grid lg:grid-cols-[auto_minmax(0,1fr)_auto] lg:px-8">
         <Link href="/" className="flex shrink-0 items-center gap-3">
           <Logo className="h-9 w-9" />
           <div className="hidden sm:block">
@@ -206,7 +206,9 @@ export function Menubar() {
                 <Menu className="h-5 w-5" />
               </button>
             </SheetTrigger>
-            <SheetContent side="right" className="w-72 border-slate-200 p-6 pt-12">
+            <SheetContent side="right" className="w-[min(18rem,calc(100vw-2.5rem))] border-slate-200 p-6 pt-12">
+              <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+              <SheetDescription className="sr-only">Jump to a page or book a session.</SheetDescription>
               <nav className="flex flex-col gap-1">
                 {[...mainNavItems, { name: 'Contact', href: '/contact' }].map((item) => {
                   const active = isActive(item.href)
@@ -215,7 +217,7 @@ export function Menubar() {
                       key={item.name}
                       href={item.href}
                       className={cn(
-                        'rounded-lg px-3 py-2.5 text-sm font-medium transition',
+                        'rounded-lg px-3 py-3 text-sm font-medium transition',
                         active
                           ? 'bg-slate-900 text-white'
                           : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900',
@@ -231,7 +233,7 @@ export function Menubar() {
               <div className="mt-4 border-t border-slate-200 pt-4">
                 <button
                   onClick={() => setMobileMoreOpen(!mobileMoreOpen)}
-                  className="flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+                  className="flex w-full items-center justify-between rounded-lg px-3 py-3 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
                 >
                   More
                   <ChevronDown className={cn('h-4 w-4 transition-transform duration-200', mobileMoreOpen && 'rotate-180')} />
@@ -245,7 +247,7 @@ export function Menubar() {
                           key={item.name}
                           href={item.href}
                           className={cn(
-                            'rounded-lg px-3 py-2 text-sm font-medium transition',
+                            'rounded-lg px-3 py-2.5 text-sm font-medium transition',
                             active
                               ? 'bg-slate-100 text-slate-900'
                               : 'text-slate-600 hover:bg-slate-100',
@@ -268,14 +270,14 @@ export function Menubar() {
                     </div>
                     <Link
                       href="/dashboard"
-                      className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-4 py-2.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                      className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-4 py-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
                     >
                       <User className="h-4 w-4" />
                       Dashboard
                     </Link>
                     <button
                       onClick={handleLogout}
-                      className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-red-200 px-4 py-2.5 text-sm font-medium text-red-600 transition hover:bg-red-50"
+                      className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-red-200 px-4 py-3 text-sm font-medium text-red-600 transition hover:bg-red-50"
                     >
                       <LogOut className="h-4 w-4" />
                       Sign out
@@ -283,7 +285,7 @@ export function Menubar() {
                   </div>
                 ) : (
                   <Link href="/login">
-                    <button className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-200 px-4 py-2.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50">
+                    <button className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-slate-200 px-4 py-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50">
                       <User className="h-4 w-4" />
                       Sign in
                     </button>
@@ -291,7 +293,7 @@ export function Menubar() {
                 )}
                 <div className="mt-3">
                   <Link href="/book">
-                    <button className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-slate-800">
+                    <button className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800">
                       <Calendar className="h-4 w-4" />
                       Book a session
                     </button>

--- a/resources/js/Pages/Contact.tsx
+++ b/resources/js/Pages/Contact.tsx
@@ -229,7 +229,7 @@ export default function Contact() {
                     </section>
 
                     {/* Contact Form Section */}
-                    <section className="py-32 bg-gray-50">
+                    <section className="py-20 sm:py-28 lg:py-32 bg-gray-50">
                         <div className="container mx-auto px-4">
                             <motion.div
                                 initial={{opacity: 0, y: 20}}
@@ -247,7 +247,7 @@ export default function Contact() {
                                             transition={{ duration: 0.3 }}
                                         >
                                             <form onSubmit={handleSubmit}
-                                                  className="space-y-8 bg-white p-12 rounded-xl shadow-lg border border-gray-100">
+                                                  className="space-y-8 bg-white p-6 sm:p-10 lg:p-12 rounded-xl shadow-lg border border-gray-100">
                                                 <input type="hidden" name="referrer" value={referrer} />
                                                 <div className="space-y-3">
                                                     <Label htmlFor="name" className="text-lg font-medium">Name <span className="text-red-500">*</span></Label>
@@ -422,7 +422,7 @@ export default function Contact() {
                                                     <div className="mt-2 flex flex-wrap gap-2">
                                                         {selectedServices.map((service) => (
                                                             <span key={service}
-                                                                  className="amber-100 text-amber-700 px-2 py-1 rounded-full text-sm">
+                                                                  className="bg-amber-100 text-amber-700 px-2 py-1 rounded-full text-sm">
                             {service}
                                                             <button type="button" onClick={() => toggleService(service)}
                                                                     className="ml-2 focus:outline-none">
@@ -459,7 +459,7 @@ export default function Contact() {
                                     {showEnvelope && (
                                         <motion.div
                                             key="confirmation"
-                                            className="bg-white p-12 rounded-xl shadow-lg border border-gray-100"
+                                            className="bg-white p-6 sm:p-10 lg:p-12 rounded-xl shadow-lg border border-gray-100"
                                             initial={{ opacity: 0, y: 20 }}
                                             animate={{ opacity: 1, y: 0 }}
                                             exit={{ opacity: 0, y: -20 }}

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -79,29 +79,29 @@ export default function Dashboard({ stats, recentPosts, draftPostsList }: Props)
             </Head>
 
             <div className="py-6 sm:py-12">
-                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8 space-y-6">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-6">
                     {/* Stats Cards */}
                     <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                        <div className="bg-white dark:bg-neutral-800 shadow-sm sm:rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
+                        <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
                             <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Total Posts</p>
                             <p className="text-2xl sm:text-3xl font-semibold text-neutral-900 dark:text-white mt-1">{stats.totalPosts}</p>
                         </div>
-                        <div className="bg-white dark:bg-neutral-800 shadow-sm sm:rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
+                        <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
                             <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Published</p>
                             <p className="text-2xl sm:text-3xl font-semibold text-emerald-600 dark:text-emerald-400 mt-1">{stats.publishedPosts}</p>
                         </div>
-                        <div className="bg-white dark:bg-neutral-800 shadow-sm sm:rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
+                        <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
                             <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Drafts</p>
                             <p className="text-2xl sm:text-3xl font-semibold text-amber-600 dark:text-amber-400 mt-1">{stats.draftPosts}</p>
                         </div>
-                        <div className="bg-white dark:bg-neutral-800 shadow-sm sm:rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
+                        <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
                             <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Preview Ready</p>
                             <p className="text-2xl sm:text-3xl font-semibold text-blue-600 dark:text-blue-400 mt-1">{stats.previewReadyDrafts}</p>
                         </div>
                     </div>
 
                     {/* Recent Published Posts */}
-                    <div className="bg-white dark:bg-neutral-800 shadow-sm sm:rounded-lg border border-neutral-200 dark:border-neutral-700">
+                    <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg border border-neutral-200 dark:border-neutral-700">
                         <div className="px-4 sm:px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
                             <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Recent Published Posts</h3>
                         </div>
@@ -132,7 +132,7 @@ export default function Dashboard({ stats, recentPosts, draftPostsList }: Props)
                     </div>
 
                     {/* Draft Posts */}
-                    <div className="bg-white dark:bg-neutral-800 shadow-sm sm:rounded-lg border border-neutral-200 dark:border-neutral-700">
+                    <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg border border-neutral-200 dark:border-neutral-700">
                         <div className="px-4 sm:px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
                             <h3 className="text-lg font-semibold text-amber-600 dark:text-amber-400">Draft Posts</h3>
                         </div>
@@ -171,7 +171,7 @@ export default function Dashboard({ stats, recentPosts, draftPostsList }: Props)
                     </div>
 
                     {/* Quick Actions */}
-                    <div className="bg-white dark:bg-neutral-800 shadow-sm sm:rounded-lg border border-neutral-200 dark:border-neutral-700">
+                    <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg border border-neutral-200 dark:border-neutral-700">
                         <div className="px-4 sm:px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
                             <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Quick Actions</h3>
                         </div>

--- a/resources/js/Pages/Products.tsx
+++ b/resources/js/Pages/Products.tsx
@@ -120,9 +120,9 @@ export default function Products() {
             {products.map((product) => (
               <div
                 key={product.name}
-                className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-8 shadow-sm transition-all hover:shadow-md sm:p-10"
+                className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-all hover:shadow-md sm:p-8 md:p-10"
               >
-                <div className="flex items-start gap-5">
+                <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
                   {/* Real logo */}
                   <div className={cn(
                     "flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-slate-100",


### PR DESCRIPTION
## Summary
- Fixes the actual mobile menu bug: the header used `grid` with columns only defined at `lg:`, so below that breakpoint it collapsed to one column and the hamburger dropped to a second row under the logo.
- Adds a visually-hidden `SheetTitle`/`SheetDescription` to the mobile drawer (was throwing Radix a11y console warnings on every open).
- Bumps mobile drawer tap targets to ~44px and caps drawer width on very narrow phones (320px) so the tap-to-close overlay strip isn't razor thin.
- Fixes an oversized fixed `w-80` profile image on About that overflowed the viewport at 320px.
- Fixes a missing `bg-` prefix on Contact's selected-service pills (rendered with no fill at any width).
- Tightens cramped padding on Contact's form/confirmation cards and hero stat spacing on the homepage.
- Fixes Products cards and Dashboard panels cramming/losing rounded corners at mobile widths.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Live-verified via Chrome MCP / CDP mobile emulation at 390x844 and 320x568 across Menubar, Home, About, Contact, Book, Blog (listing + detail), Products, Footer; Dashboard reviewed at source level (auth-gated)
- [x] Desktop layout re-verified unchanged (grid nav, centered pill, right-side actions)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layouts across the About, Products, Contact, and Dashboard pages.
  * Refined hero image sizing, spacing, card presentation, and contact form styling.
  * Adjusted dashboard statistics, draft posts, and quick action card layouts.
  * Improved mobile navigation spacing, button sizing, and accessibility labels.
  * Enhanced responsive typography and spacing in the hero statistics section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->