### PR TITLE
Fix backend security and health issues from full-codebase audit

### DIFF
--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,0 +1,117 @@
+---
+name: security-auditor
+description: Use PROACTIVELY for dedicated security review of this Laravel/Inertia/React codebase — authorization/IDOR bugs, injection (SQL, XSS, header/email), secret exposure, dependency CVEs, session/cookie misconfig, SSRF, open redirects, mass assignment. Read-only: it finds and reports, it does not patch code.
+tools: Read, Grep, Glob, Bash, WebSearch, ToolSearch
+model: opus
+---
+
+## What you do
+
+Full-codebase security audit of a Laravel 13 + Inertia + React (TypeScript)
+portfolio/SaaS-ish app: public marketing pages, a blog with comments, bio
+links with click analytics and geo-targeting, short links, contact and
+newsletter forms, and an authenticated dashboard (Breeze + Sanctum). You
+find real, exploitable security bugs — not style nits, not hypothetical
+defense-in-depth suggestions unless they're cheap and clearly warranted.
+
+## Where to look (specific to this codebase's shape)
+
+- **Authorization / IDOR** — `app/Http/Controllers/Admin/*` (BioLinkController,
+  ShortLinkController) and `app/Http/Middleware/CheckRole.php`. For every
+  admin/dashboard route: does it actually check the acting user owns the
+  resource being mutated, or just that they're logged in? Try to find a route
+  where swapping an ID in the URL/payload would let one user touch another
+  user's bio link, short link, or click data.
+- **Mass assignment** — every Eloquent model in `app/Models/` (`BioLink`,
+  `BioLinkClick`, `BlogCommentThread`, `ContactSubmission`, `ShortLink`,
+  `ShortLinkClick`, `Subscriber`, `User`). Check `$fillable`/`$guarded` against
+  every `::create()`/`fill()`/`update()` call site that passes a raw
+  `$request->all()` or unvalidated array — a missing `$fillable` boundary
+  lets a client set fields like `role`, `user_id`, or `is_admin` it shouldn't.
+- **Injection** — `grep -rn "DB::raw\|whereRaw\|selectRaw\|->raw(" app/` for
+  unparameterized SQL. `grep -rn "dangerouslySetInnerHTML" resources/js/` (at
+  least `CaseStudyArticleBody.tsx` uses it for markdown-rendered HTML — trace
+  where that HTML originates; if it's ever attacker-influenced — blog
+  comments, contact form, newsletter, any user-submitted content — that's
+  stored/reflected XSS, not just static-content-authored-by-Harun-only HTML,
+  which would be fine).
+- **Open redirect / SSRF** — `ShortLinkController` and any redirect logic:
+  does it validate the destination URL/scheme, or blindly `redirect($input)`?
+  `app/Services/CountryResolver.php` and the `geoip2/geoip2` integration —
+  does IP geolocation ever take a client-controlled hostname/URL rather than
+  the request's own IP (SSRF vector), and is the local MaxMind DB path
+  trusted input or hardcoded?
+- **Auth flows** — everything under `app/Http/Controllers/Auth/` plus
+  `SocialAuthenticationController.php`: password reset token handling,
+  email verification bypass, session fixation after login/social-auth,
+  whether Sanctum config (`config/sanctum.php`) scopes stateful domains
+  correctly, rate limiting on login/password-reset/registration
+  (`RouteServiceProvider`/`routes/auth.php`/`bootstrap/app.php` throttle
+  middleware).
+- **Secrets & config** — confirm `.env` isn't git-tracked (`git ls-files |
+  grep '^\.env$'` should be empty) but also grep tracked files for hardcoded
+  keys/tokens: `grep -rnE "(api[_-]?key|secret|password|token)\s*=\s*['\"][A-Za-z0-9]{16,}" --include='*.php' --include='*.tsx' --include='*.ts' --include='*.js' --include='*.yml' --include='*.yaml' .` (excluding `node_modules`, `vendor`). Check `config/*.php`
+  for anything reading a default/fallback secret instead of failing closed.
+  Check `APP_DEBUG` / `APP_ENV` handling — confirm nothing in the repo forces
+  debug mode on in a way that could ship to production (stack traces leaking
+  paths/env vars).
+- **CSRF** — Inertia + Laravel handles this by default via the
+  `VerifyCsrfToken` middleware; confirm no route explicitly excludes itself
+  from CSRF protection (`except` array in that middleware or
+  `withoutMiddleware` calls) without good reason (webhooks are a legitimate
+  exception — verify any excluded route instead validates a signature).
+- **Dependency CVEs** — run `composer audit` and `npm audit --production` if
+  available; for anything they flag, use WebSearch to confirm the CVE is
+  real and check whether this app's actual usage of the package hits the
+  vulnerable code path (don't just parrot the audit tool's severity label).
+- **Cookies/session** — `config/session.php`: `secure`, `http_only`,
+  `same_site` settings appropriate for a site served over HTTPS.
+- **File uploads / user content** — blog comments
+  (`BlogCommentController.php`, `ryangjchandler/laravel-comments` package)
+  and contact submissions: any unvalidated file upload, unescaped rendering
+  of submitted content, or missing spam/rate limiting.
+- **Email injection** — `ContactController.php`, `NewsletterController.php`,
+  and anything using `resend-laravel`: are user-submitted values (name,
+  subject, message) interpolated into email headers unsanitized (header
+  injection), or only into the body (safe)?
+
+## Process
+
+1. Read the relevant controllers/models/middleware/config for each area
+   above — don't just grep-and-guess; open the file and trace the actual
+   request-to-response path.
+2. For every candidate finding, write out the concrete exploit: what request
+   would an attacker send, as what user (anonymous / authenticated-non-owner
+   / authenticated-owner), and what does it get them. If you can't articulate
+   a concrete request that breaks something, it's not a finding — note it as
+   a "worth hardening" aside instead, clearly separated from real bugs.
+3. Rate each real finding's severity (critical / high / medium / low) based
+   on actual impact (data exposure across users, account takeover, RCE) vs.
+   exploitability (anonymous/one-click vs. requires an already-privileged
+   account).
+4. Don't edit any files. Report only.
+
+## Output format
+
+Return a markdown report with one section per finding, most severe first:
+
+```
+### [SEVERITY] Short title
+**File:** path:line
+**Issue:** what's wrong
+**Exploit:** concrete request/steps an attacker would take
+**Fix:** the specific code change that closes it (describe it, don't apply it)
+```
+
+End with a short "Reviewed, found clean" list of the areas you checked that
+had no issues, so it's clear what was actually covered vs. skipped.
+
+## What you don't do
+
+- Don't patch code — you're read-only. A separate step applies fixes.
+- Don't report generic security "advice" (e.g. "consider a WAF", "add 2FA")
+  unless the user's own auth flow has a concrete gap that specific advice
+  closes. Every finding needs a real exploit path in this codebase.
+- Don't flag Laravel/Inertia framework defaults as bugs (e.g. CSRF, escaping
+  in Blade) without evidence they've been disabled or bypassed here.
+- Don't commit, branch, PR, or deploy.

--- a/app/Http/Controllers/Admin/BioLinkController.php
+++ b/app/Http/Controllers/Admin/BioLinkController.php
@@ -2,19 +2,20 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Admin\Concerns\HasClickAnalytics;
 use App\Http\Controllers\Controller;
 use App\Models\BioLink;
 use App\Models\BioLinkClick;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class BioLinkController extends Controller
 {
+    use HasClickAnalytics;
+
     public function index(): Response
     {
         return Inertia::render('Admin/Bio/Index', [
@@ -49,92 +50,16 @@ class BioLinkController extends Controller
             'days' => $days,
             'totalClicks' => BioLinkClick::count(),
             'windowClicks' => (clone $clicks)->count(),
-            'daily' => $this->dailySeries($since, $days),
-            'byLink' => $this->clicksByLink($since),
-            'byCountry' => $this->groupCounts((clone $clicks), 'country'),
-            'byReferer' => $this->refererCounts((clone $clicks)),
-        ]);
-    }
-
-    /**
-     * One row per day in the window, including days with no clicks -- a bar
-     * chart with gaps silently rescales the x axis and misreads as continuous.
-     *
-     * @return list<array{date: string, clicks: int}>
-     */
-    private function dailySeries(\DateTimeInterface $since, int $days): array
-    {
-        $counts = BioLinkClick::query()
-            ->where('created_at', '>=', $since)
-            ->selectRaw('date(created_at) as day, count(*) as clicks')
-            ->groupBy('day')
-            ->pluck('clicks', 'day');
-
-        return collect(range(0, $days - 1))
-            ->map(function (int $offset) use ($since, $counts) {
-                $date = Carbon::parse($since)->addDays($offset)->toDateString();
-
-                return [
-                    'date' => $date,
-                    'clicks' => (int) ($counts[$date] ?? 0),
-                ];
-            })
-            ->all();
-    }
-
-    /**
-     * @return list<array{id: int, label: string, icon: string, clicks: int}>
-     */
-    private function clicksByLink(\DateTimeInterface $since): array
-    {
-        return BioLink::query()
-            ->withCount(['clicks as clicks' => fn ($q) => $q->where('created_at', '>=', $since)])
-            ->orderByDesc('clicks')
-            ->get()
-            ->map(fn (BioLink $link) => [
+            'daily' => $this->dailySeries(BioLinkClick::query(), $since, $days),
+            'byLink' => $this->clicksByLink(BioLink::query(), $since, fn (BioLink $link) => [
                 'id' => $link->id,
                 'label' => $link->label,
                 'icon' => $link->icon,
                 'clicks' => (int) $link->clicks,
-            ])
-            ->all();
-    }
-
-    /**
-     * @return list<array{key: string, clicks: int}>
-     */
-    private function groupCounts(Builder $query, string $column): array
-    {
-        return $query
-            ->whereNotNull($column)
-            ->selectRaw("{$column} as key, count(*) as clicks")
-            ->groupBy($column)
-            ->orderByDesc('clicks')
-            ->limit(10)
-            ->get()
-            ->map(fn ($row) => ['key' => (string) $row->key, 'clicks' => (int) $row->clicks])
-            ->all();
-    }
-
-    /**
-     * Referers are grouped by host: the full URL fragments the counts into
-     * near-duplicates that say nothing about where traffic came from.
-     *
-     * @return list<array{key: string, clicks: int}>
-     */
-    private function refererCounts(Builder $query): array
-    {
-        return $query
-            ->whereNotNull('referer')
-            ->pluck('referer')
-            ->map(fn (?string $url) => $url ? (parse_url($url, PHP_URL_HOST) ?: null) : null)
-            ->filter()
-            ->countBy()
-            ->sortDesc()
-            ->take(10)
-            ->map(fn (int $clicks, string $host) => ['key' => $host, 'clicks' => $clicks])
-            ->values()
-            ->all();
+            ]),
+            'byCountry' => $this->groupCounts((clone $clicks), 'country'),
+            'byReferer' => $this->refererCounts((clone $clicks)),
+        ]);
     }
 
     public function store(Request $request): RedirectResponse

--- a/app/Http/Controllers/Admin/Concerns/HasClickAnalytics.php
+++ b/app/Http/Controllers/Admin/Concerns/HasClickAnalytics.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * Shared click-analytics helpers for the bio-link and short-link admin
+ * dashboards. Both track clicks against a per-link table with the same shape
+ * (created_at, country, referer), so the aggregation logic is identical.
+ */
+trait HasClickAnalytics
+{
+    /**
+     * One row per day in the window, including days with no clicks -- a bar
+     * chart with gaps silently rescales the x axis and misreads as continuous.
+     *
+     * The click query is passed in already scoped (e.g. to a single link) so
+     * callers keep control over which rows are counted.
+     *
+     * @return list<array{date: string, clicks: int}>
+     */
+    protected function dailySeries(Builder $clicks, \DateTimeInterface $since, int $days): array
+    {
+        $counts = $clicks
+            ->where('created_at', '>=', $since)
+            ->selectRaw('date(created_at) as day, count(*) as clicks')
+            ->groupBy('day')
+            ->pluck('clicks', 'day');
+
+        return collect(range(0, $days - 1))
+            ->map(function (int $offset) use ($since, $counts) {
+                $date = Carbon::parse($since)->addDays($offset)->toDateString();
+
+                return [
+                    'date' => $date,
+                    'clicks' => (int) ($counts[$date] ?? 0),
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * Clicks per link within the window. The link model and the shape of each
+     * returned row differ between dashboards, so the caller supplies both the
+     * base query and a mapper.
+     *
+     * @param  callable(Model): array<string, mixed>  $mapper
+     * @return list<array<string, mixed>>
+     */
+    protected function clicksByLink(Builder $links, \DateTimeInterface $since, callable $mapper): array
+    {
+        return $links
+            ->withCount(['clicks as clicks' => fn ($q) => $q->where('created_at', '>=', $since)])
+            ->orderByDesc('clicks')
+            ->get()
+            ->map($mapper)
+            ->all();
+    }
+
+    /**
+     * @return list<array{key: string, clicks: int}>
+     */
+    protected function groupCounts(Builder $query, string $column): array
+    {
+        return $query
+            ->whereNotNull($column)
+            ->selectRaw("{$column} as key, count(*) as clicks")
+            ->groupBy($column)
+            ->orderByDesc('clicks')
+            ->limit(10)
+            ->get()
+            ->map(fn ($row) => ['key' => (string) $row->key, 'clicks' => (int) $row->clicks])
+            ->all();
+    }
+
+    /**
+     * Referers are grouped by host: the full URL fragments the counts into
+     * near-duplicates that say nothing about where traffic came from.
+     *
+     * @return list<array{key: string, clicks: int}>
+     */
+    protected function refererCounts(Builder $query): array
+    {
+        return $query
+            ->whereNotNull('referer')
+            ->pluck('referer')
+            ->map(fn (?string $url) => $url ? (parse_url($url, PHP_URL_HOST) ?: null) : null)
+            ->filter()
+            ->countBy()
+            ->sortDesc()
+            ->take(10)
+            ->map(fn (int $clicks, string $host) => ['key' => $host, 'clicks' => $clicks])
+            ->values()
+            ->all();
+    }
+}

--- a/app/Http/Controllers/Admin/ShortLinkController.php
+++ b/app/Http/Controllers/Admin/ShortLinkController.php
@@ -2,19 +2,21 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Http\Controllers\Admin\Concerns\HasClickAnalytics;
 use App\Http\Controllers\Controller;
 use App\Models\ShortLink;
 use App\Models\ShortLinkClick;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class ShortLinkController extends Controller
 {
+    use HasClickAnalytics;
+
     public function index(): Response
     {
         return Inertia::render('Admin/Short/Index', [
@@ -58,97 +60,16 @@ class ShortLinkController extends Controller
             'selectedLinkId' => $linkId,
             'totalClicks' => $scoped(ShortLinkClick::query())->count(),
             'windowClicks' => (clone $clicks)->count(),
-            'daily' => $this->dailySeries($since, $days, $linkId),
-            'byLink' => $linkId ? [] : $this->clicksByLink($since),
-            'byCountry' => $this->groupCounts((clone $clicks), 'country'),
-            'byReferer' => $this->refererCounts((clone $clicks)),
-        ]);
-    }
-
-    /**
-     * One row per day in the window, including days with no clicks -- a bar
-     * chart with gaps silently rescales the x axis and misreads as continuous.
-     *
-     * @return list<array{date: string, clicks: int}>
-     */
-    private function dailySeries(\DateTimeInterface $since, int $days, ?int $linkId): array
-    {
-        $query = ShortLinkClick::query()->where('created_at', '>=', $since);
-
-        if ($linkId) {
-            $query->where('short_link_id', $linkId);
-        }
-
-        $counts = $query
-            ->selectRaw('date(created_at) as day, count(*) as clicks')
-            ->groupBy('day')
-            ->pluck('clicks', 'day');
-
-        return collect(range(0, $days - 1))
-            ->map(function (int $offset) use ($since, $counts) {
-                $date = Carbon::parse($since)->addDays($offset)->toDateString();
-
-                return [
-                    'date' => $date,
-                    'clicks' => (int) ($counts[$date] ?? 0),
-                ];
-            })
-            ->all();
-    }
-
-    /**
-     * @return list<array{id: int, code: string, title: ?string, clicks: int}>
-     */
-    private function clicksByLink(\DateTimeInterface $since): array
-    {
-        return ShortLink::query()
-            ->withCount(['clicks as clicks' => fn ($q) => $q->where('created_at', '>=', $since)])
-            ->orderByDesc('clicks')
-            ->get()
-            ->map(fn (ShortLink $link) => [
+            'daily' => $this->dailySeries($scoped(ShortLinkClick::query()), $since, $days),
+            'byLink' => $linkId ? [] : $this->clicksByLink(ShortLink::query(), $since, fn (ShortLink $link) => [
                 'id' => $link->id,
                 'code' => $link->code,
                 'title' => $link->title,
                 'clicks' => (int) $link->clicks,
-            ])
-            ->all();
-    }
-
-    /**
-     * @return list<array{key: string, clicks: int}>
-     */
-    private function groupCounts(Builder $query, string $column): array
-    {
-        return $query
-            ->whereNotNull($column)
-            ->selectRaw("{$column} as key, count(*) as clicks")
-            ->groupBy($column)
-            ->orderByDesc('clicks')
-            ->limit(10)
-            ->get()
-            ->map(fn ($row) => ['key' => (string) $row->key, 'clicks' => (int) $row->clicks])
-            ->all();
-    }
-
-    /**
-     * Referers are grouped by host: the full URL fragments the counts into
-     * near-duplicates that say nothing about where traffic came from.
-     *
-     * @return list<array{key: string, clicks: int}>
-     */
-    private function refererCounts(Builder $query): array
-    {
-        return $query
-            ->whereNotNull('referer')
-            ->pluck('referer')
-            ->map(fn (?string $url) => $url ? (parse_url($url, PHP_URL_HOST) ?: null) : null)
-            ->filter()
-            ->countBy()
-            ->sortDesc()
-            ->take(10)
-            ->map(fn (int $clicks, string $host) => ['key' => $host, 'clicks' => $clicks])
-            ->values()
-            ->all();
+            ]),
+            'byCountry' => $this->groupCounts((clone $clicks), 'country'),
+            'byReferer' => $this->refererCounts((clone $clicks)),
+        ]);
     }
 
     public function store(Request $request): RedirectResponse

--- a/app/Mail/ContactFormMail.php
+++ b/app/Mail/ContactFormMail.php
@@ -2,14 +2,12 @@
 
 namespace App\Mail;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 
-class ContactFormMail extends Mailable implements ShouldQueue
+class ContactFormMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use SerializesModels;
 
     public array $data;
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,9 +20,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'role' => \App\Http\Middleware\CheckRole::class,
         ]);
 
-        // Exclude Resend webhook from CSRF protection
+        // These endpoints are called without a CSRF token (client-side beacons).
         $middleware->validateCsrfTokens(except: [
-            'resend/*',
             'blog/*/view',
             'bio/click',
         ]);

--- a/database/migrations/2026_07_27_100000_add_analytics_index_to_short_link_clicks_table.php
+++ b/database/migrations/2026_07_27_100000_add_analytics_index_to_short_link_clicks_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('short_link_clicks', function (Blueprint $table) {
+            // Every analytics query filters by link and groups over a date range.
+            $table->index(['short_link_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('short_link_clicks', function (Blueprint $table) {
+            $table->dropIndex(['short_link_id', 'created_at']);
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,7 +38,9 @@ Route::get('/', function () {
     return Inertia::render('Homepage');
 })->name('home');
 
-Route::get('/dashboard', function () {
+// The same admin dashboard view is served at both /dashboard and /admin, so
+// the payload-building logic lives in one closure shared by both routes.
+$renderDashboard = function () {
     $blog = new BlogRepository();
     $posts = $blog->posts();
     $publishedPosts = array_values(array_filter($posts, fn (array $post) => ! (bool) ($post['draft'] ?? false)));
@@ -63,34 +65,15 @@ Route::get('/dashboard', function () {
             'draftPreviewUrl' => $blog->previewUrl((string) $post['slug']),
         ], $draftPosts),
     ]);
-})->middleware(['auth', 'verified', 'role:admin'])->name('dashboard');
+};
 
-Route::get('/admin', function () {
-    $blog = new BlogRepository();
-    $posts = $blog->posts();
-    $publishedPosts = array_values(array_filter($posts, fn (array $post) => ! (bool) ($post['draft'] ?? false)));
-    $draftPosts = array_values(array_filter($posts, fn (array $post) => (bool) ($post['draft'] ?? false)));
+Route::get('/dashboard', $renderDashboard)
+    ->middleware(['auth', 'verified', 'role:admin'])
+    ->name('dashboard');
 
-    return Inertia::render('Dashboard', [
-        'stats' => [
-            'totalPosts' => count($posts),
-            'publishedPosts' => count($publishedPosts),
-            'draftPosts' => count($draftPosts),
-            'previewReadyDrafts' => count(array_filter($draftPosts, fn (array $post) => ! empty($blog->previewUrl((string) $post['slug'])))),
-        ],
-        'panelStatus' => 'Ready',
-        'panelStatusDetail' => 'Protected by auth + verified and wired to the live blog content source.',
-        'recentPosts' => array_slice($blog->indexPosts(), 0, 5),
-        'draftPostsList' => array_map(fn (array $post) => [
-            'title' => (string) $post['title'],
-            'slug' => (string) $post['slug'],
-            'brief' => (string) $post['brief'],
-            'publishedAtHuman' => (string) ($post['publishedAtHuman'] ?? ''),
-            'readTimeLabel' => (string) ($post['readTimeLabel'] ?? ''),
-            'draftPreviewUrl' => $blog->previewUrl((string) $post['slug']),
-        ], $draftPosts),
-    ]);
-})->middleware(['auth', 'verified', 'role:admin'])->name('admin');
+Route::get('/admin', $renderDashboard)
+    ->middleware(['auth', 'verified', 'role:admin'])
+    ->name('admin');
 
 // Admin CRUD for link-in-bio entries
 Route::middleware(['auth', 'verified', 'role:admin'])
@@ -202,7 +185,7 @@ Route::post('/bio/click', function (Request $request, CountryResolver $countries
     ]);
 
     return response()->noContent();
-})->name('bio.click');
+})->middleware('throttle:30,1')->name('bio.click');
 
 Route::get('/about', function () {
     return Inertia::render('About');
@@ -288,9 +271,13 @@ Route::get('/contact', function () {
     return Inertia::render('Contact');
 })->name('contact');
 
-Route::post('/contact', [ContactController::class, 'submit'])->name('contact.submit');
+Route::post('/contact', [ContactController::class, 'submit'])
+    ->middleware('throttle:5,1')
+    ->name('contact.submit');
 
-Route::post('/subscribe', [NewsletterController::class, 'subscribe'])->name('subscribe');
+Route::post('/subscribe', [NewsletterController::class, 'subscribe'])
+    ->middleware('throttle:5,1')
+    ->name('subscribe');
 
 Route::get('/case-studies', function (Request $request) {
     if ($request->getRequestUri() === '/case-studies/') {
@@ -462,7 +449,7 @@ Route::post('/blog/{slug}/view', function (string $slug) {
     $count = $viewRow ? (int) $viewRow->count : 0;
     \Illuminate\Support\Facades\Cache::put("post.views.".$slug, $count, 3600);
     return response()->json(['views' => $count]);
-})->name('blog.view');
+})->middleware('throttle:30,1')->name('blog.view');
 
 // Blog post
 Route::get('/blog/{slug}', function (Request $request, string $slug) {

--- a/tests/Feature/ContactSubmissionTest.php
+++ b/tests/Feature/ContactSubmissionTest.php
@@ -48,7 +48,9 @@ class ContactSubmissionTest extends TestCase
         $this->assertEquals(['Cloud Architecture', 'DevOps'], $submission->services);
         $this->assertEquals('sent', $submission->status);
 
-        Mail::assertQueued(ContactFormMail::class);
+        // The mailable sends synchronously (no queue worker runs in this app),
+        // so it lands in the "sent" bucket rather than the "queued" bucket.
+        Mail::assertSent(ContactFormMail::class);
     }
 
     #[Test]
@@ -58,7 +60,7 @@ class ContactSubmissionTest extends TestCase
 
         $response->assertSessionHasErrors(['name', 'email', 'subject', 'message']);
         $this->assertDatabaseCount('contact_submissions', 0);
-        Mail::assertNothingQueued();
+        Mail::assertNothingSent();
     }
 
     #[Test]
@@ -75,7 +77,7 @@ class ContactSubmissionTest extends TestCase
 
         $response->assertSessionHasErrors(['email']);
         $this->assertDatabaseCount('contact_submissions', 0);
-        Mail::assertNothingQueued();
+        Mail::assertNothingSent();
     }
 
     #[Test]
@@ -188,7 +190,7 @@ class ContactSubmissionTest extends TestCase
         $response2->assertRedirect();
 
         $this->assertDatabaseCount('contact_submissions', 2);
-        Mail::assertQueued(ContactFormMail::class, 2);
+        Mail::assertSent(ContactFormMail::class, 2);
     }
 
     #[Test]
@@ -274,6 +276,10 @@ class ContactSubmissionTest extends TestCase
     #[Test]
     public function it_validates_email_with_various_formats()
     {
+        // This case fires well over a dozen submissions to exercise validation;
+        // the /contact rate limiter is not what's under test here, so skip it.
+        $this->withoutMiddleware(\Illuminate\Routing\Middleware\ThrottleRequests::class);
+
         $validEmails = [
             'test@example.com',
             'test+label@example.com',


### PR DESCRIPTION
## Summary
- Contact form emails were silently never delivered: `ContactFormMail` implemented `ShouldQueue`, so `Mail::to()->send()` enqueued instead of sending, and no queue worker exists anywhere in this app's infra. Removed `ShouldQueue`.
- Added rate limiting (`throttle:30,1` on click/view beacons, `throttle:5,1` on contact/subscribe) to stop anonymous abuse.
- Removed a dead `resend/*` CSRF exemption — no such route exists.
- Deduped ~50 duplicated lines between the `/dashboard` and `/admin` route closures into one shared closure.
- Added a composite index on `short_link_clicks` matching the one `bio_link_clicks` already has for the same query pattern.
- Extracted duplicated click-analytics aggregation logic (`dailySeries`, `clicksByLink`, `groupCounts`, `refererCounts`) out of `BioLinkController`/`ShortLinkController` into a shared `HasClickAnalytics` trait.
- Added a reusable `security-auditor` subagent (used to find these issues) for future audits.

## Test plan
- [x] `php -l` clean on all touched PHP files
- [x] `php artisan route:list` registers all routes without error
- [x] Full test suite: 105 passed / 12 failed, byte-identical to the pre-change baseline (all 12 failures are pre-existing test-isolation issues unrelated to this change, confirmed by stashing and re-running)
- [x] `php artisan migrate:status` confirms the new index migration applies cleanly

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added throttling to public click-tracking, contact, subscription, and blog-view endpoints.
  * Updated CSRF handling for client-side beacon requests.

* **Analytics**
  * Improved admin analytics dashboards with shared reporting logic and more efficient click-data queries.
  * Added a database index to support faster analytics loading.

* **Email**
  * Contact form emails are now sent immediately instead of being queued.

* **Administration**
  * Unified dashboard access and rendering across dashboard entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->