### PR TITLE
Add scheduler service and HTTP-to-HTTPS redirect

### DIFF
--- a/deploy/cicd/server-deploy.sh
+++ b/deploy/cicd/server-deploy.sh
@@ -248,7 +248,18 @@ deploy_to_environment() {
   docker compose -f $APP_DIR/docker/docker-compose.yml exec -T php_$target_env php artisan route:clear
   docker compose -f $APP_DIR/docker/docker-compose.yml exec -T php_$target_env php artisan config:clear
   docker compose -f $APP_DIR/docker/docker-compose.yml exec -T php_$target_env php artisan route:cache
-  
+
+  # Rebuild and restart the scheduler with the new code. It is a single persistent
+  # instance outside the blue/green swap (like db) that runs scheduled artisan
+  # commands (e.g. publishing scheduled posts, hourly inspire). A scheduler failure
+  # is lower stakes than serving live traffic, so warn and continue rather than
+  # aborting or rolling back the primary web deploy.
+  if docker compose -f $APP_DIR/docker/docker-compose.yml up -d --build scheduler; then
+    success "Scheduler service rebuilt and restarted"
+  else
+    warning "Scheduler service failed to rebuild/restart; continuing with deploy (scheduled tasks may be stale until next deploy)"
+  fi
+
   success "$target_env environment deployed successfully"
 }
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,6 +23,22 @@ services:
       - internal
       - app-network
 
+  scheduler:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: php-fpm
+    container_name: scheduler
+    env_file:
+      - .env
+    restart: unless-stopped
+    # The image ENTRYPOINT (/entrypoint-php.sh) runs its setup then `exec "$@"`,
+    # so overriding command here cleanly replaces php-fpm with the scheduler loop.
+    command: ["sh", "-c", "while true; do php artisan schedule:run --no-interaction; sleep 60; done"]
+    networks:
+      - internal
+      - app-network
+
   nginx_blue:
     build:
       context: ..

--- a/docker/traefik-dynamic.yml
+++ b/docker/traefik-dynamic.yml
@@ -4,6 +4,8 @@ http:
       rule: "Host(`harun.dev`)"
       entryPoints:
         - web
+      middlewares:
+        - https-redirect
       service: web-blue
     web-main-secure:
       rule: "Host(`harun.dev`)"
@@ -14,6 +16,11 @@ http:
         certResolver: le
         domains:
           - main: "harun.dev"
+  middlewares:
+    https-redirect:
+      redirectScheme:
+        scheme: https
+        permanent: true
   services:
     web-blue:
       loadBalancer:


### PR DESCRIPTION
## Summary
- Laravel's task scheduler never ran in production: no worker/cron process existed anywhere in the docker-compose stack, so `schedule:run` never executed and scheduled jobs (auto-publishing scheduled blog posts, hourly `inspire`) were silently dead. Added a persistent `scheduler` service (outside the blue/green swap, like `db`) that loops `schedule:run` every 60s.
- Wired the scheduler rebuild into `server-deploy.sh` as a non-fatal step (warns on failure, doesn't abort/rollback the primary web deploy).
- Added an HTTP→HTTPS redirect middleware on the plain-HTTP Traefik router — `http://harun.dev` now 301s to https instead of serving over plaintext.

## Test plan
- [x] `docker compose -f docker/docker-compose.yml config` validates cleanly
- [x] Confirmed the middleware name doesn't collide with the deploy script's `service: web-[color]` sed pattern used during traffic switches
- [x] Confirmed Traefik's ACME HTTP-01 challenge handling isn't affected by the new redirect
- [x] `bash -n deploy/cicd/server-deploy.sh` syntax-checks clean
- [ ] Watch the live deploy to confirm the scheduler container starts and `http://harun.dev` redirects to https

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE