### PR TITLE
Fix frontend audit findings: broken bio-edit form, dead code

### DIFF
--- a/resources/js/Pages/Admin/Bio/Edit.tsx
+++ b/resources/js/Pages/Admin/Bio/Edit.tsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout'
-import { Head, router, useForm } from '@inertiajs/react'
+import { Head, useForm } from '@inertiajs/react'
 import BioLinkForm, { type BioLinkFormData } from './Partials/BioLinkForm'
 
 interface BioLinkRecord {
@@ -20,7 +20,7 @@ interface BioLinkRecord {
 }
 
 export default function Edit({ link }: { link: BioLinkRecord }) {
-  const { data, setData, processing, errors } = useForm<BioLinkFormData>({
+  const { data, setData, post, transform, processing, errors } = useForm<BioLinkFormData>({
     label: link.label,
     description: link.description ?? '',
     url: link.url,
@@ -41,7 +41,8 @@ export default function Edit({ link }: { link: BioLinkRecord }) {
     e.preventDefault()
     // PHP never populates $_FILES for PUT bodies, multipart or not, so a real
     // file upload has to ride in on a POST with a spoofed _method instead.
-    router.post(`/admin/bio/${link.id}`, { ...data, _method: 'put' }, { forceFormData: true })
+    transform((data) => ({ ...data, _method: 'put' }))
+    post(`/admin/bio/${link.id}`, { forceFormData: true })
   }
 
   return (

--- a/resources/js/Pages/Auth/ConfirmPassword.tsx
+++ b/resources/js/Pages/Auth/ConfirmPassword.tsx
@@ -5,7 +5,6 @@ import TextInput from '@/Components/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
-import { getImageUrl } from "@/lib/imageUtils"
 
 export default function ConfirmPassword() {
     const { data, setData, post, processing, errors, reset } = useForm({

--- a/resources/js/Pages/Auth/ForgotPassword.tsx
+++ b/resources/js/Pages/Auth/ForgotPassword.tsx
@@ -4,7 +4,6 @@ import TextInput from '@/Components/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
-import { getImageUrl } from "@/lib/imageUtils"
 
 export default function ForgotPassword({ status }: { status?: string }) {
     const { data, setData, post, processing, errors } = useForm({

--- a/resources/js/Pages/Auth/Register.tsx
+++ b/resources/js/Pages/Auth/Register.tsx
@@ -6,7 +6,6 @@ import TextInput from '@/Components/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
-import { getImageUrl } from "@/lib/imageUtils"
 
 export default function Register() {
     const { data, setData, post, processing, errors, reset } = useForm({

--- a/resources/js/Pages/Auth/ResetPassword.tsx
+++ b/resources/js/Pages/Auth/ResetPassword.tsx
@@ -5,7 +5,6 @@ import TextInput from '@/Components/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { Head, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
-import { getImageUrl } from "@/lib/imageUtils"
 
 export default function ResetPassword({
     token,

--- a/resources/js/Pages/Auth/VerifyEmail.tsx
+++ b/resources/js/Pages/Auth/VerifyEmail.tsx
@@ -2,7 +2,6 @@ import PrimaryButton from '@/Components/PrimaryButton';
 import GuestLayout from '@/Layouts/GuestLayout';
 import { Head, Link, useForm } from '@inertiajs/react';
 import { FormEventHandler } from 'react';
-import { getImageUrl } from "@/lib/imageUtils"
 
 export default function VerifyEmail({ status }: { status?: string }) {
     const { post, processing } = useForm({});

--- a/resources/js/Pages/Products.tsx
+++ b/resources/js/Pages/Products.tsx
@@ -1,5 +1,6 @@
 import { Head, Link } from "@inertiajs/react"
 import { ExternalLink, Link as LinkIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
 
 const products = [
   {
@@ -192,9 +193,4 @@ export default function Products() {
       </div>
     </>
   )
-}
-
-// Helper for conditional classes
-function cn(...classes: (string | boolean | undefined | null)[]) {
-  return classes.filter(Boolean).join(" ")
 }

--- a/resources/js/Pages/Profile/Edit.tsx
+++ b/resources/js/Pages/Profile/Edit.tsx
@@ -4,7 +4,6 @@ import { Head } from '@inertiajs/react';
 import DeleteUserForm from './Partials/DeleteUserForm';
 import UpdatePasswordForm from './Partials/UpdatePasswordForm';
 import UpdateProfileInformationForm from './Partials/UpdateProfileInformationForm';
-import { getImageUrl } from "@/lib/imageUtils"
 
 export default function Edit({
     mustVerifyEmail,

--- a/resources/js/Pages/Services/AWSCloud.tsx
+++ b/resources/js/Pages/Services/AWSCloud.tsx
@@ -1,5 +1,3 @@
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/AutomatedDeployment.tsx
+++ b/resources/js/Pages/Services/AutomatedDeployment.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/CloudArchitecture.tsx
+++ b/resources/js/Pages/Services/CloudArchitecture.tsx
@@ -3,8 +3,6 @@
 import React, { useEffect, useRef, useState } from "react"
 import { Head } from "@inertiajs/react"
 import { motion } from "framer-motion"
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card/index"

--- a/resources/js/Pages/Services/DatabaseMigration.tsx
+++ b/resources/js/Pages/Services/DatabaseMigration.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/DatabaseOptimization.tsx
+++ b/resources/js/Pages/Services/DatabaseOptimization.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/DevOps.tsx
+++ b/resources/js/Pages/Services/DevOps.tsx
@@ -3,8 +3,6 @@
 import React, { useEffect, useRef, useState } from "react"
 import { Head, Link } from "@inertiajs/react"
 import { motion } from "framer-motion"
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card/index"

--- a/resources/js/Pages/Services/InfrastructureAsCode.tsx
+++ b/resources/js/Pages/Services/InfrastructureAsCode.tsx
@@ -3,8 +3,6 @@
 import React, { useEffect, useRef, useState } from "react"
 import { Head, Link } from "@inertiajs/react"
 import { motion } from "framer-motion"
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card/index"

--- a/resources/js/Pages/Services/InfrastructureMigration.tsx
+++ b/resources/js/Pages/Services/InfrastructureMigration.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/MLOps.tsx
+++ b/resources/js/Pages/Services/MLOps.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/MonitoringObservability.tsx
+++ b/resources/js/Pages/Services/MonitoringObservability.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/MultiCloudArchitecture.tsx
+++ b/resources/js/Pages/Services/MultiCloudArchitecture.tsx
@@ -1,5 +1,3 @@
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/PerformanceOptimization.tsx
+++ b/resources/js/Pages/Services/PerformanceOptimization.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/SecurityConsulting.tsx
+++ b/resources/js/Pages/Services/SecurityConsulting.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"

--- a/resources/js/Pages/Services/ServerlessInfrastructure.tsx
+++ b/resources/js/Pages/Services/ServerlessInfrastructure.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Menubar } from "@/Components/Menubar"
-import { Footer } from "@/Components/Footer"
 import { ServiceHero } from "@/Components/ServiceHero"
 import { Button } from "@/Components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/Components/ui/card"


### PR DESCRIPTION
## Summary
- `Admin/Bio/Edit.tsx` called the standalone `router.post()` instead of the `useForm`-bound `post()`, so `processing`/`errors` state never updated and server validation errors silently never reached the UI. Switched to the form's own `post()`/`transform()`.
- Removed a dead `getImageUrl` import from 6 Auth/Profile pages.
- Removed dead `Menubar`/`Footer` imports across 14 Services pages.
- Removed a local `cn()` duplicate in `Products.tsx` in favor of the shared `@/lib/utils` import.

## Test plan
- [x] `npx tsc --noEmit` clean

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE