### PR TITLE
Fix broken link and trailing-slash duplicates from GSC audit

### DIFF
--- a/app/Http/Middleware/RedirectTrailingSlash.php
+++ b/app/Http/Middleware/RedirectTrailingSlash.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectTrailingSlash
+{
+    /**
+     * Normalize trailing-slash URLs to their canonical, slash-free form.
+     *
+     * Canonical <link> tags are rendered client-side by Inertia/React, so the
+     * raw HTML Google crawls never carries them. Without a real HTTP redirect,
+     * "/blog/some-post/" and "/blog/some-post" both return 200 with identical
+     * content, which Search Console flags as "Duplicate without user-selected
+     * canonical". A 301 to the slash-free URL gives crawlers one authority.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Only touch safe, cacheable navigations. POST/PUT/DELETE form
+        // submissions and beacons must never be bounced by a redirect.
+        if ($request->isMethod('GET') || $request->isMethod('HEAD')) {
+            $path = $request->getPathInfo();
+
+            // Skip the homepage ("/"): there is no trailing slash to strip.
+            // Everything else that ends in "/" is redirected to the same URL
+            // without it, preserving scheme, host, and the query string.
+            if ($path !== '/' && str_ends_with($path, '/')) {
+                $query = $request->getQueryString();
+                $target = rtrim($request->url(), '/').($query !== null ? '?'.$query : '');
+
+                return redirect()->to($target, 301);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,6 +11,12 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        // Runs before session/CSRF so trailing-slash URLs are normalized to
+        // their canonical (slash-free) form with a 301 before any real work.
+        $middleware->web(prepend: [
+            \App\Http\Middleware\RedirectTrailingSlash::class,
+        ]);
+
         $middleware->web(append: [
             \App\Http\Middleware\HandleInertiaRequests::class,
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,

--- a/resources/blog/posts/first-3-things-i-always-do-after-creating-a-new-aws-account.md
+++ b/resources/blog/posts/first-3-things-i-always-do-after-creating-a-new-aws-account.md
@@ -83,7 +83,7 @@ Everything is the same as the first alert, only change Trigger to <strong>Foreca
 <p>You need the root account for a few <a target="_blank" href="https://docs.aws.amazon.com/accounts/latest/reference/root-user-tasks.html">tasks</a>. Other than that you should not use the Root account. Perhaps, not for day-to-day tasks, lunching, and provisioning services. </p>
 <p>I always create an IAM account with admin permission. I do all of the tasks from this account except those tasks that require the root account. So, let's create an admin IAM account. </p>
 <ol>
-<li>Go to <a target="_blank" href="console.aws.amazon.com/iamv2/home#/users"><strong>Users page of IAM Console</strong></a>.</li>
+<li>Go to <a target="_blank" href="https://console.aws.amazon.com/iamv2/home#/users"><strong>Users page of IAM Console</strong></a>.</li>
 <li>Click on the <strong>Add users</strong> button from top-right corner. </li>
 <li>You will be in this page:
 <img src="/blog-assets/first-3-things-i-always-do-after-creating-a-new-aws-account/qnRC-GFHY.png" alt="CleanShot 2022-07-06 at 19.42.16@2x.png" /><ul>

--- a/tests/Feature/TrailingSlashRedirectTest.php
+++ b/tests/Feature/TrailingSlashRedirectTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\RedirectTrailingSlash;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class TrailingSlashRedirectTest extends TestCase
+{
+    /**
+     * Laravel's HTTP test helpers ($this->get('/foo/')) strip the trailing
+     * slash in prepareUrlForRequest() before the request is even built, so a
+     * trailing-slash URL cannot be expressed through them. We therefore drive
+     * the middleware directly with a Request that preserves the raw path.
+     */
+    private function dispatch(string $uri, string $method = 'GET'): Response
+    {
+        $middleware = new RedirectTrailingSlash();
+        $request = Request::create($uri, $method);
+
+        return $middleware->handle($request, fn () => new Response('reached-route'));
+    }
+
+    #[Test]
+    public function it_redirects_a_trailing_slash_path_to_the_canonical_form(): void
+    {
+        $response = $this->dispatch('http://127.0.0.1:8123/services/');
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('http://127.0.0.1:8123/services', $response->headers->get('Location'));
+    }
+
+    #[Test]
+    public function it_redirects_a_nested_trailing_slash_path(): void
+    {
+        $response = $this->dispatch('http://127.0.0.1:8123/blog/production-ai-code-review-for-terraform-and-lambda-prs/');
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame(
+            'http://127.0.0.1:8123/blog/production-ai-code-review-for-terraform-and-lambda-prs',
+            $response->headers->get('Location'),
+        );
+    }
+
+    #[Test]
+    public function it_preserves_the_query_string_when_stripping_the_slash(): void
+    {
+        $response = $this->dispatch('http://127.0.0.1:8123/blog/?page=2&tag=aws');
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('http://127.0.0.1:8123/blog?page=2&tag=aws', $response->headers->get('Location'));
+    }
+
+    #[Test]
+    public function it_leaves_the_bare_homepage_untouched(): void
+    {
+        $response = $this->dispatch('http://127.0.0.1:8123/');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('reached-route', $response->getContent());
+    }
+
+    #[Test]
+    public function it_does_not_touch_a_path_without_a_trailing_slash(): void
+    {
+        $response = $this->dispatch('http://127.0.0.1:8123/services');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('reached-route', $response->getContent());
+    }
+
+    #[Test]
+    public function it_does_not_redirect_non_get_requests(): void
+    {
+        $response = $this->dispatch('http://127.0.0.1:8123/services/', 'POST');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('reached-route', $response->getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed a protocol-less `href` in `first-3-things-i-always-do-after-creating-a-new-aws-account.md` that resolved as a relative path and 404'd live (flagged in Google Search Console's "Not found (404)" report). Swept all other blog posts for the same bug class — no other instances found.
- Added `RedirectTrailingSlash` middleware: 301-redirects any trailing-slash URL (except the bare homepage) to its canonical slash-free form, preserving the query string. This fixes GSC's "Duplicate without user-selected canonical" flag — canonical `<link>` tags only render client-side via Inertia/React, so Google's raw-HTML crawl never sees them, and the app previously had no HTTP-level redirect resolving the ambiguity.

## Test plan
- [x] New `TrailingSlashRedirectTest` (6 tests) passing on a fresh `main` checkout
- [x] Live curl verification: `/services/` → 301 → `/services`, `/blog/{slug}/` → 301 → `/blog/{slug}`, query strings preserved, homepage and non-slash paths untouched
- [x] Confirmed no regression: ran full suite with the middleware toggled off/on to isolate — 3 pre-existing, unrelated `BlogSeoTest` failures reproduce identically either way (draft-post 404 handling, out of scope for this PR)
- [x] Grepped all `resources/blog/posts/*.md` for the same missing-protocol-href bug class — none remaining

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized trailing-slash URLs by redirecting them to their canonical slash-free versions.
  * Preserved query parameters during URL redirects.
  * Left the homepage and non-GET requests unchanged.

* **Documentation**
  * Updated the AWS IAM Console link to use a fully qualified URL.

* **Tests**
  * Added coverage for redirects, nested paths, query strings, homepage behavior, and non-redirect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->