### PR TITLE
Fix trailing-slash redirect double-hopping through http://

### DIFF
--- a/app/Http/Middleware/RedirectTrailingSlash.php
+++ b/app/Http/Middleware/RedirectTrailingSlash.php
@@ -29,7 +29,24 @@ class RedirectTrailingSlash
             // without it, preserving scheme, host, and the query string.
             if ($path !== '/' && str_ends_with($path, '/')) {
                 $query = $request->getQueryString();
-                $target = rtrim($request->url(), '/').($query !== null ? '?'.$query : '');
+
+                // TLS is terminated at the edge (Cloudflare/Traefik) and the
+                // request reaches PHP over plain HTTP, so $request->url() would
+                // report the scheme as "http" and 301 to an http:// target. The
+                // edge then bounces that a SECOND time back to https, producing
+                // the 2-hop chain crawlers penalize. The edge tells us the real
+                // client-facing scheme via X-Forwarded-Proto (Traefik forwards
+                // "https" for TLS-terminated requests), so honour that to emit
+                // the correct https:// canonical in a single hop. Fall back to
+                // the request's own scheme for local dev over plain http, where
+                // no proxy sits in front and the header is absent.
+                $forwardedProto = $request->header('X-Forwarded-Proto');
+                $scheme = $forwardedProto !== null
+                    ? trim(explode(',', $forwardedProto)[0])
+                    : $request->getScheme();
+
+                $target = $scheme.'://'.$request->getHttpHost().$request->getBaseUrl().$request->getPathInfo();
+                $target = rtrim($target, '/').($query !== null ? '?'.$query : '');
 
                 return redirect()->to($target, 301);
             }

--- a/tests/Feature/TrailingSlashRedirectTest.php
+++ b/tests/Feature/TrailingSlashRedirectTest.php
@@ -16,10 +16,10 @@ class TrailingSlashRedirectTest extends TestCase
      * trailing-slash URL cannot be expressed through them. We therefore drive
      * the middleware directly with a Request that preserves the raw path.
      */
-    private function dispatch(string $uri, string $method = 'GET'): Response
+    private function dispatch(string $uri, string $method = 'GET', array $server = []): Response
     {
         $middleware = new RedirectTrailingSlash();
-        $request = Request::create($uri, $method);
+        $request = Request::create($uri, $method, [], [], [], $server);
 
         return $middleware->handle($request, fn () => new Response('reached-route'));
     }
@@ -43,6 +43,35 @@ class TrailingSlashRedirectTest extends TestCase
             'http://127.0.0.1:8123/blog/production-ai-code-review-for-terraform-and-lambda-prs',
             $response->headers->get('Location'),
         );
+    }
+
+    #[Test]
+    public function it_redirects_to_https_in_one_hop_when_the_edge_forwards_https(): void
+    {
+        // Production: Cloudflare/Traefik terminate TLS and forward the request
+        // to PHP over plain HTTP, so the request URI is http:// but the edge
+        // sets X-Forwarded-Proto: https. Without honouring that header the
+        // middleware 301s to http://, which the edge bounces a second time
+        // back to https — the 2-hop chain we are eliminating here.
+        $response = $this->dispatch(
+            'http://harun.dev/services/',
+            server: ['HTTP_X_FORWARDED_PROTO' => 'https'],
+        );
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('https://harun.dev/services', $response->headers->get('Location'));
+    }
+
+    #[Test]
+    public function it_honours_the_first_scheme_in_a_forwarded_proto_chain(): void
+    {
+        $response = $this->dispatch(
+            'http://harun.dev/blog/',
+            server: ['HTTP_X_FORWARDED_PROTO' => 'https, http'],
+        );
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame('https://harun.dev/blog', $response->headers->get('Location'));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- The `RedirectTrailingSlash` middleware from #106 was live-verified to be producing a 2-hop redirect chain: `https://harun.dev/services/` → 301 → `http://harun.dev/services` → 301 → `https://harun.dev/services`. TLS terminates at the edge (Cloudflare/Traefik) and PHP sees the request as plain HTTP with no trusted-proxy config in the app, so `$request->url()` resolved to an `http://` target.
- Fix: derive the redirect scheme from `X-Forwarded-Proto` (falling back to the request's own scheme when absent, e.g. local dev), so production emits a single clean 301 straight to the `https://` canonical.

## Test plan
- [x] New tests reproducing the exact production scenario (`X-Forwarded-Proto: https` on an `http://` request URI) and a forwarded-proto chain — both fail against the pre-fix code, pass after
- [x] Full `TrailingSlashRedirectTest` suite: 8 passed (16 assertions)
- [ ] After merge/deploy: live curl confirming `https://harun.dev/services/` → single 301 → `https://harun.dev/services` (no intermediate `http://` hop)

## Note for later (not in this PR)
The subagent that found this flagged a wider issue: this app has no `trustProxies()` configuration at all in `bootstrap/app.php`, so every Laravel URL helper (`url()`, `route()`, `asset()`, sitemap generation, etc.) is potentially subject to the same http-vs-https scheme misdetection in production, not just this one middleware. Worth a dedicated look separately.

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE