### PR TITLE
Support a Tailscale preview URL with https scheme forcing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ APP_KEY=
 APP_DEBUG=true
 APP_TIMEZONE=UTC
 APP_URL=http://localhost
+# Optional second origin (e.g. a Tailscale Serve address) for previewing a
+# local branch before it ships. Leave blank unless you're running a preview
+# service; see the preview.plist service for how this gets set locally.
+PREVIEW_URL=
 APP_BUILD_VERSION=local
 APP_DEPLOYMENT_ID=local
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,13 +22,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $canonicalHost = parse_url((string) config('app.url'), PHP_URL_HOST);
+        $httpsHosts = collect([config('app.url'), config('app.preview_url')])
+            ->filter(fn ($url) => is_string($url) && str_starts_with($url, 'https://'))
+            ->map(fn ($url) => parse_url($url, PHP_URL_HOST))
+            ->filter();
 
-        if (
-            $canonicalHost !== null
-            && request()->getHost() === $canonicalHost
-            && str_starts_with((string) config('app.url'), 'https://')
-        ) {
+        if ($httpsHosts->contains(request()->getHost())) {
             URL::forceScheme('https');
         }
 

--- a/config/app.php
+++ b/config/app.php
@@ -54,6 +54,20 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Preview URL
+    |--------------------------------------------------------------------------
+    |
+    | An optional second origin the app is reachable at besides "url" above,
+    | such as a Tailscale Serve address used to preview a local branch before
+    | it ships. When set to an "https://" URL, requests arriving on this
+    | host also get their scheme forced to https for asset/URL generation.
+    |
+    */
+
+    'preview_url' => env('PREVIEW_URL'),
+
     'build_version' => env('APP_BUILD_VERSION', 'local'),
 
     'deployment_id' => env('APP_DEPLOYMENT_ID', 'local'),


### PR DESCRIPTION
## Summary
- Adds an optional `PREVIEW_URL` env/config so a second origin (e.g. a Tailscale Serve address) can preview a branch locally before it ships
- `AppServiceProvider` now forces https URL generation on either the canonical `APP_URL` host or the `PREVIEW_URL` host, instead of only the canonical one

## Test plan
- [x] Manually verified: this session is being previewed live via `https://mx.ewe-ulmer.ts.net:8443` (the `PREVIEW_URL`), confirming https asset/URL generation works on the preview host
- [x] `php artisan test` — no regressions from this change (pre-existing unrelated failures only, see below)
- [x] `npx tsc --noEmit` clean, `npm run build` succeeds

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional preview URL configuration for branch previews.
  * HTTPS is now enforced for both the primary application URL and configured preview URL.
* **Documentation**
  * Added setup guidance and comments for configuring the optional preview URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->