### PR TITLE
Embed Google Slides on the slide detail page

### DIFF
--- a/resources/js/Pages/Media/Detail.tsx
+++ b/resources/js/Pages/Media/Detail.tsx
@@ -1,5 +1,5 @@
 import { Head, Link } from '@inertiajs/react'
-import { ArrowLeft, CalendarDays, MonitorPlay, Presentation } from 'lucide-react'
+import { ArrowLeft, CalendarDays, ExternalLink, MonitorPlay, Presentation } from 'lucide-react'
 
 type MediaItemDetail = {
   slug: string
@@ -48,7 +48,7 @@ export default function MediaDetailPage({ type, item, related, canonicalUrl }: P
   const Icon = type === 'slide' ? Presentation : MonitorPlay
   const title = `${item.title} | Harun R. Rayhan`
   const description = item.summary || copy.fallbackDescription
-  const showEmbed = type === 'video' && item.embedUrl !== null
+  const showEmbed = item.embedUrl !== null
 
   return (
     <>
@@ -89,15 +89,26 @@ export default function MediaDetailPage({ type, item, related, canonicalUrl }: P
 
           <div className="mt-10">
             {showEmbed ? (
-              <div className="relative aspect-video overflow-hidden rounded-[2rem] border border-slate-200 bg-slate-950">
-                <iframe
-                  src={item.embedUrl as string}
-                  title={item.title}
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                  allowFullScreen
-                  className="absolute inset-0 h-full w-full border-0"
-                />
-              </div>
+              <>
+                <div className="relative aspect-video overflow-hidden rounded-[2rem] border border-slate-200 bg-slate-950">
+                  <iframe
+                    src={item.embedUrl as string}
+                    title={item.title}
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    allowFullScreen
+                    className="absolute inset-0 h-full w-full border-0"
+                  />
+                </div>
+                <a
+                  href={item.shareUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-950"
+                >
+                  Open full screen
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+              </>
             ) : (
               <div className="relative aspect-video overflow-hidden rounded-[2rem] border border-slate-200 bg-slate-100">
                 {item.thumbnailUrl ? (

--- a/routes/web.php
+++ b/routes/web.php
@@ -387,6 +387,27 @@ if (! function_exists('mediaItemYoutubeEmbedUrl')) {
     }
 }
 
+if (! function_exists('mediaItemSlideEmbedUrl')) {
+    /**
+     * Turn a Google Slides link (edit or Publish-to-web form) into its embed
+     * form, or null if $url isn't a recognizable Google Slides link. Used by
+     * the slide detail route; a non-Google-Slides URL falls back to the
+     * thumbnail + "View slides" button instead of an iframe.
+     */
+    function mediaItemSlideEmbedUrl(string $url): ?string
+    {
+        $pattern = '#docs\.google\.com/presentation/d/(e/)?([a-zA-Z0-9_-]+)#i';
+
+        if (! preg_match($pattern, $url, $match)) {
+            return null;
+        }
+
+        $path = $match[1].$match[2];
+
+        return "https://docs.google.com/presentation/d/{$path}/embed?start=false&loop=false&delayms=3000";
+    }
+}
+
 Route::get('/slides', function (Request $request) {
     $siteUrl = rtrim(config('app.url', url('/')), '/');
 
@@ -427,7 +448,7 @@ Route::get('/slides/{slug}', function (string $slug) {
             'sourceLabel' => $item->source_label,
             'publishedAtHuman' => $item->published_at?->format('M j, Y'),
             'shareUrl' => $item->share_url,
-            'embedUrl' => null, // slides never embed
+            'embedUrl' => mediaItemSlideEmbedUrl($item->url),
         ],
         'related' => $related->map(fn (MediaItem $r) => [
             'slug' => $r->slug, 'title' => $r->title,

--- a/tests/Feature/MediaItemTest.php
+++ b/tests/Feature/MediaItemTest.php
@@ -96,4 +96,20 @@ class MediaItemTest extends TestCase
 
         $this->assertCount(0, $page['props']['items']);
     }
+
+    public function test_google_slides_edit_url_resolves_to_an_embed_url(): void
+    {
+        $embedUrl = mediaItemSlideEmbedUrl('https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/edit#slide=id.p1');
+
+        $this->assertSame(
+            'https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/embed?start=false&loop=false&delayms=3000',
+            $embedUrl
+        );
+    }
+
+    public function test_a_non_google_slides_url_does_not_resolve_to_an_embed_url(): void
+    {
+        $this->assertNull(mediaItemSlideEmbedUrl('https://example.com/deck.pdf'));
+        $this->assertNull(mediaItemSlideEmbedUrl('https://speakerdeck.com/harun/scaling-serverless'));
+    }
 }


### PR DESCRIPTION
## Summary
- `/slides/{slug}` now resolves `embedUrl` via a new `mediaItemSlideEmbedUrl()` helper in `routes/web.php` (mirrors the existing `mediaItemYoutubeEmbedUrl()` used by `/videos/{slug}`), recognizing both the Google Slides "edit" URL and the Publish-to-web `.../d/e/{id}/pub` form; anything else falls back to `null`.
- `resources/js/Pages/Media/Detail.tsx`: `showEmbed` is no longer gated to `type === 'video'` — any item (slide or video) with a resolved `embedUrl` now renders the iframe; non-embeddable items keep the existing thumbnail + CTA fallback.
- Added a small tracked "Open full screen" link (via the `/s/{code}` share URL) directly below the embed, since embedded items previously had zero tracked outbound link.
- `tests/Feature/MediaItemTest.php`: added coverage for `mediaItemSlideEmbedUrl()` — the Google Slides edit-URL happy path, and the `null` fallback for a non-Google-Slides URL.

## Test plan
- [x] `php artisan test --filter=MediaItemTest` — 6 passed (15 assertions), including the 2 new cases
- [x] `npx tsc --noEmit` — clean, no output
- [x] `npm run build` — succeeded (pre-existing >500kB chunk warning only, expected)
- [x] `git status --short` — confirmed `npm run build` produced no tracked changes (`public/build` is gitignored)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE