### PR TITLE
Standardize experience and client numbers (15+ years / 160+ clients)

### DIFF
--- a/resources/js/Components/AboutHero.tsx
+++ b/resources/js/Components/AboutHero.tsx
@@ -18,7 +18,7 @@ export function AboutHero() {
           >
             <h1 className="text-4xl lg:text-5xl font-bold mb-6 text-white">About</h1>
             <p className="text-xl text-white/90 mb-8 max-w-2xl mx-auto lg:mx-0">
-              With over 17 years of experience in software engineering, cloud architecture, and DevOps, I've dedicated
+              With over 15 years of experience in software engineering, cloud architecture, and DevOps, I've dedicated
               my career to building scalable solutions and empowering teams through innovation and best practices.
             </p>
             <motion.div

--- a/resources/js/Components/HeroSectionV2.tsx
+++ b/resources/js/Components/HeroSectionV2.tsx
@@ -20,8 +20,8 @@ const logos = [
 ]
 
 const highlights = [
-    { label: 'Experience', value: '10+ years' },
-    { label: 'Clients', value: '120+ served' },
+    { label: 'Experience', value: '15+ years' },
+    { label: 'Clients', value: '160+ served' },
     { label: 'Focus', value: 'AWS + DevOps' },
 ]
 

--- a/resources/js/Components/ReviewSlideSection.tsx
+++ b/resources/js/Components/ReviewSlideSection.tsx
@@ -185,7 +185,7 @@ export function ReviewSlideSection() {
                     className="mt-14 grid gap-4 sm:grid-cols-3"
                 >
                     {[
-                        { value: '120+', label: 'Happy clients' },
+                        { value: '160+', label: 'Happy clients' },
                         { value: '4.8/5', label: 'Average rating' },
                         { value: '98%', label: 'Success rate' },
                     ].map((item) => (

--- a/resources/js/Components/SkillsSection.tsx
+++ b/resources/js/Components/SkillsSection.tsx
@@ -34,7 +34,7 @@ const skills = [
 ]
 
 const highlights = [
-    { value: '17+', label: 'years building software' },
+    { value: '15+', label: 'years building software' },
     { value: '12×', label: 'AWS certified' },
     { value: 'Lead', label: 'technical mentoring' },
 ]

--- a/resources/js/Pages/Media/Detail.tsx
+++ b/resources/js/Pages/Media/Detail.tsx
@@ -1,5 +1,5 @@
 import { Head, Link } from '@inertiajs/react'
-import { ArrowLeft, CalendarDays, MonitorPlay, Presentation } from 'lucide-react'
+import { ArrowLeft, CalendarDays, ExternalLink, MonitorPlay, Presentation } from 'lucide-react'
 
 type MediaItemDetail = {
   slug: string
@@ -48,7 +48,7 @@ export default function MediaDetailPage({ type, item, related, canonicalUrl }: P
   const Icon = type === 'slide' ? Presentation : MonitorPlay
   const title = `${item.title} | Harun R. Rayhan`
   const description = item.summary || copy.fallbackDescription
-  const showEmbed = type === 'video' && item.embedUrl !== null
+  const showEmbed = item.embedUrl !== null
 
   return (
     <>
@@ -89,15 +89,26 @@ export default function MediaDetailPage({ type, item, related, canonicalUrl }: P
 
           <div className="mt-10">
             {showEmbed ? (
-              <div className="relative aspect-video overflow-hidden rounded-[2rem] border border-slate-200 bg-slate-950">
-                <iframe
-                  src={item.embedUrl as string}
-                  title={item.title}
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                  allowFullScreen
-                  className="absolute inset-0 h-full w-full border-0"
-                />
-              </div>
+              <>
+                <div className="relative aspect-video overflow-hidden rounded-[2rem] border border-slate-200 bg-slate-950">
+                  <iframe
+                    src={item.embedUrl as string}
+                    title={item.title}
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    allowFullScreen
+                    className="absolute inset-0 h-full w-full border-0"
+                  />
+                </div>
+                <a
+                  href={item.shareUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-950"
+                >
+                  Open full screen
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+              </>
             ) : (
               <div className="relative aspect-video overflow-hidden rounded-[2rem] border border-slate-200 bg-slate-100">
                 {item.thumbnailUrl ? (

--- a/routes/web.php
+++ b/routes/web.php
@@ -387,6 +387,27 @@ if (! function_exists('mediaItemYoutubeEmbedUrl')) {
     }
 }
 
+if (! function_exists('mediaItemSlideEmbedUrl')) {
+    /**
+     * Turn a Google Slides link (edit or Publish-to-web form) into its embed
+     * form, or null if $url isn't a recognizable Google Slides link. Used by
+     * the slide detail route; a non-Google-Slides URL falls back to the
+     * thumbnail + "View slides" button instead of an iframe.
+     */
+    function mediaItemSlideEmbedUrl(string $url): ?string
+    {
+        $pattern = '#docs\.google\.com/presentation/d/(e/)?([a-zA-Z0-9_-]+)#i';
+
+        if (! preg_match($pattern, $url, $match)) {
+            return null;
+        }
+
+        $path = $match[1].$match[2];
+
+        return "https://docs.google.com/presentation/d/{$path}/embed?start=false&loop=false&delayms=3000";
+    }
+}
+
 Route::get('/slides', function (Request $request) {
     $siteUrl = rtrim(config('app.url', url('/')), '/');
 
@@ -427,7 +448,7 @@ Route::get('/slides/{slug}', function (string $slug) {
             'sourceLabel' => $item->source_label,
             'publishedAtHuman' => $item->published_at?->format('M j, Y'),
             'shareUrl' => $item->share_url,
-            'embedUrl' => null, // slides never embed
+            'embedUrl' => mediaItemSlideEmbedUrl($item->url),
         ],
         'related' => $related->map(fn (MediaItem $r) => [
             'slug' => $r->slug, 'title' => $r->title,

--- a/tests/Feature/MediaItemTest.php
+++ b/tests/Feature/MediaItemTest.php
@@ -96,4 +96,20 @@ class MediaItemTest extends TestCase
 
         $this->assertCount(0, $page['props']['items']);
     }
+
+    public function test_google_slides_edit_url_resolves_to_an_embed_url(): void
+    {
+        $embedUrl = mediaItemSlideEmbedUrl('https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/edit#slide=id.p1');
+
+        $this->assertSame(
+            'https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/embed?start=false&loop=false&delayms=3000',
+            $embedUrl
+        );
+    }
+
+    public function test_a_non_google_slides_url_does_not_resolve_to_an_embed_url(): void
+    {
+        $this->assertNull(mediaItemSlideEmbedUrl('https://example.com/deck.pdf'));
+        $this->assertNull(mediaItemSlideEmbedUrl('https://speakerdeck.com/harun/scaling-serverless'));
+    }
 }


### PR DESCRIPTION
## What

Aligns every years-of-experience and client-count claim on the site to a single consistent story: **15+ years of experience** and **160+ clients**. Previously these were inconsistent and outdated across components (10+, 17, 120+).

## Root cause

The numbers were hardcoded independently in several components, so different pages advertised different figures.

## Files changed

- `resources/js/Components/HeroSectionV2.tsx` — Experience `10+ years` -> `15+ years`; Clients `120+ served` -> `160+ served`
- `resources/js/Components/AboutHero.tsx` — "over **17** years of experience" -> "over **15** years of experience" (rest of sentence unchanged)
- `resources/js/Components/ReviewSlideSection.tsx` — Happy clients `120+` -> `160+`
- `resources/js/Components/SkillsSection.tsx` — `17+` -> `15+` years building software (found via broader sweep, not in the original list)

## Deliberately left unchanged

- `resources/js/Components/FAQSection.tsx` — "over 7 years of AWS experience" is a distinct, narrower AWS-specific claim, not overall years, so it stays.

## Verification

- Broadened the search beyond the four known spots: checked JSON-LD / schema.org `Person` and `ProfessionalService` markup, meta/OG/Twitter descriptions, `Bio.tsx`, `Contact.tsx`, `Dashboard.tsx`, `Services.tsx`, all `Services/*` subpages, and blog/case-study content. No other stray experience or client numbers reference the site-wide story (blog/case-study "15 years old" mentions are about a PHP framework's age, unrelated). No CV/resume file exists in `public/`.
- Re-ran the sweep after editing: zero remaining `10+`, `17`, or `120+` experience/client references.

## Test plan

- [x] `npx tsc --noEmit` — passes, no errors
- [x] `npm run build` — succeeds (only the pre-existing chunk-size warning)
- [ ] Visually confirm hero stats, About intro, review stats, and skills highlights all read 15+ years / 160+ clients

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedded viewing for supported Google Slides content.
  * Added an “Open full screen” link for embedded media.
* **Content Updates**
  * Updated displayed experience statistics to 15+ years.
  * Updated client statistics to 160+ served and 160+ happy clients.
* **Bug Fixes**
  * Improved media detail pages to display available embed content beyond video items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->