### PR TITLE
Add Railway referral link to bio Tools tab

### DIFF
--- a/database/migrations/2026_07_29_100000_seed_railway_bio_link.php
+++ b/database/migrations/2026_07_29_100000_seed_railway_bio_link.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\BioLink;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Seeds the /bio "Tools" tab (declared as slug 'tools' in Bio.tsx) with a
+ * Railway referral link. `tab` stays 'Tools' so BioLink::booted() derives the
+ * matching 'tools' slug and the link lands in the existing declared tab
+ * instead of spawning a new group. Priority 10 keeps it consistent with the
+ * first-entry convention used by the AI, Cashback, and Products tabs.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        BioLink::updateOrCreate(
+            ['url' => 'https://railway.com?referralCode=55c4MI'],
+            [
+                'label' => 'Railway',
+                'description' => 'Sign up with my link and get $20 credit.',
+                'icon' => 'link',
+                'tab' => 'Tools',
+                'priority' => 10,
+                'is_active' => true,
+                'featured' => false,
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        BioLink::where('url', 'https://railway.com?referralCode=55c4MI')->delete();
+    }
+};


### PR DESCRIPTION
## Summary
- Seeds a new BioLink entry (Railway referral) into the existing Tools tab via migration, following the `BioLink::updateOrCreate` pattern used for the opencode entry.
- Verified locally: migration applies cleanly, row derives `tab_slug` = `tools`, auto-generates a `/s/{code}` short link, and renders in the Tools tab alongside the other 17 visible bio links.

## Test plan
- [x] `php artisan migrate` applies cleanly
- [x] `/bio` Tools tab shows the Railway card with the "$20 credit" description, link routes through `/s/{code}`
- [x] `php artisan migrate:rollback` removes it cleanly
- [ ] Post-deploy: confirm live on `https://harun.dev/bio?tab=tools`

Generated with [Claude Code](https://claude.ai/code)