### PR TITLE
Fix 500 on /slides/{slug} and /videos/{slug} under route caching

### DIFF
--- a/app/Support/MediaEmbeds.php
+++ b/app/Support/MediaEmbeds.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Support;
+
+class MediaEmbeds
+{
+    /**
+     * Extract an 11-character YouTube video ID from a watch/short/embed URL, or
+     * null if $url isn't a recognizable YouTube link. Used by the video detail
+     * route to build a privacy-friendly youtube-nocookie embed.
+     */
+    public static function youtubeEmbedUrl(string $url): ?string
+    {
+        $pattern = '#(?:youtube\.com/(?:watch\?v=|embed/|shorts/)|youtu\.be/)([A-Za-z0-9_-]{11})#i';
+
+        if (! preg_match($pattern, $url, $match)) {
+            return null;
+        }
+
+        return 'https://www.youtube-nocookie.com/embed/'.$match[1];
+    }
+
+    /**
+     * Turn a Google Slides link (edit or Publish-to-web form) into its embed
+     * form, or null if $url isn't a recognizable Google Slides link. Used by
+     * the slide detail route; a non-Google-Slides URL falls back to the
+     * thumbnail + "View slides" button instead of an iframe.
+     */
+    public static function slideEmbedUrl(string $url): ?string
+    {
+        $pattern = '#docs\.google\.com/presentation/d/(e/)?([a-zA-Z0-9_-]+)#i';
+
+        if (! preg_match($pattern, $url, $match)) {
+            return null;
+        }
+
+        $path = $match[1].$match[2];
+
+        return "https://docs.google.com/presentation/d/{$path}/embed?start=false&loop=false&delayms=3000";
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Models\ShortLinkClick;
 use App\Models\BlogCommentThread;
 use App\Support\BlogRepository;
 use App\Support\CaseStudyRepository;
+use App\Support\MediaEmbeds;
 use App\Services\CountryResolver;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
@@ -365,49 +366,6 @@ Route::get('/case-studies/{slug}', function (string $slug) {
     ]);
 })->name('case-studies.show');
 
-// routes/web.php is re-required on every application boot (each test case
-// builds a fresh Application), so a bare top-level function declaration
-// would fatal with "Cannot redeclare" the second time around -- guard it.
-if (! function_exists('mediaItemYoutubeEmbedUrl')) {
-    /**
-     * Extract an 11-character YouTube video ID from a watch/short/embed URL, or
-     * null if $url isn't a recognizable YouTube link. Used by the video detail
-     * route to build a privacy-friendly youtube-nocookie embed; slides never
-     * embed, so this only matters for /videos/{slug}.
-     */
-    function mediaItemYoutubeEmbedUrl(string $url): ?string
-    {
-        $pattern = '#(?:youtube\.com/(?:watch\?v=|embed/|shorts/)|youtu\.be/)([A-Za-z0-9_-]{11})#i';
-
-        if (! preg_match($pattern, $url, $match)) {
-            return null;
-        }
-
-        return 'https://www.youtube-nocookie.com/embed/'.$match[1];
-    }
-}
-
-if (! function_exists('mediaItemSlideEmbedUrl')) {
-    /**
-     * Turn a Google Slides link (edit or Publish-to-web form) into its embed
-     * form, or null if $url isn't a recognizable Google Slides link. Used by
-     * the slide detail route; a non-Google-Slides URL falls back to the
-     * thumbnail + "View slides" button instead of an iframe.
-     */
-    function mediaItemSlideEmbedUrl(string $url): ?string
-    {
-        $pattern = '#docs\.google\.com/presentation/d/(e/)?([a-zA-Z0-9_-]+)#i';
-
-        if (! preg_match($pattern, $url, $match)) {
-            return null;
-        }
-
-        $path = $match[1].$match[2];
-
-        return "https://docs.google.com/presentation/d/{$path}/embed?start=false&loop=false&delayms=3000";
-    }
-}
-
 Route::get('/slides', function (Request $request) {
     $siteUrl = rtrim(config('app.url', url('/')), '/');
 
@@ -448,7 +406,7 @@ Route::get('/slides/{slug}', function (string $slug) {
             'sourceLabel' => $item->source_label,
             'publishedAtHuman' => $item->published_at?->format('M j, Y'),
             'shareUrl' => $item->share_url,
-            'embedUrl' => mediaItemSlideEmbedUrl($item->url),
+            'embedUrl' => MediaEmbeds::slideEmbedUrl($item->url),
         ],
         'related' => $related->map(fn (MediaItem $r) => [
             'slug' => $r->slug, 'title' => $r->title,
@@ -498,7 +456,7 @@ Route::get('/videos/{slug}', function (string $slug) {
             'sourceLabel' => $item->source_label,
             'publishedAtHuman' => $item->published_at?->format('M j, Y'),
             'shareUrl' => $item->share_url,
-            'embedUrl' => mediaItemYoutubeEmbedUrl($item->url),
+            'embedUrl' => MediaEmbeds::youtubeEmbedUrl($item->url),
         ],
         'related' => $related->map(fn (MediaItem $r) => [
             'slug' => $r->slug, 'title' => $r->title,

--- a/tests/Feature/MediaItemTest.php
+++ b/tests/Feature/MediaItemTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\MediaItem;
+use App\Support\MediaEmbeds;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -99,7 +100,7 @@ class MediaItemTest extends TestCase
 
     public function test_google_slides_edit_url_resolves_to_an_embed_url(): void
     {
-        $embedUrl = mediaItemSlideEmbedUrl('https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/edit#slide=id.p1');
+        $embedUrl = MediaEmbeds::slideEmbedUrl('https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/edit#slide=id.p1');
 
         $this->assertSame(
             'https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/embed?start=false&loop=false&delayms=3000',
@@ -109,7 +110,51 @@ class MediaItemTest extends TestCase
 
     public function test_a_non_google_slides_url_does_not_resolve_to_an_embed_url(): void
     {
-        $this->assertNull(mediaItemSlideEmbedUrl('https://example.com/deck.pdf'));
-        $this->assertNull(mediaItemSlideEmbedUrl('https://speakerdeck.com/harun/scaling-serverless'));
+        $this->assertNull(MediaEmbeds::slideEmbedUrl('https://example.com/deck.pdf'));
+        $this->assertNull(MediaEmbeds::slideEmbedUrl('https://speakerdeck.com/harun/scaling-serverless'));
+    }
+
+    public function test_a_slide_detail_page_renders_the_embed_url_and_related_slides(): void
+    {
+        MediaItem::create([
+            'type' => 'slide',
+            'title' => 'Laravel DB Performance',
+            'slug' => 'laravel-db-performance',
+            'url' => 'https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/edit',
+            'is_active' => true,
+        ]);
+
+        $response = $this->withHeaders($this->inertiaHeaders())->get('/slides/laravel-db-performance');
+
+        $response->assertOk();
+        $page = $response->json();
+
+        $this->assertSame('Media/Detail', $page['component']);
+        $this->assertSame(
+            'https://docs.google.com/presentation/d/1AbCdEfGhIjKlMnOpQrStUvWxYz/embed?start=false&loop=false&delayms=3000',
+            $page['props']['item']['embedUrl']
+        );
+    }
+
+    public function test_a_video_detail_page_renders_the_embed_url(): void
+    {
+        MediaItem::create([
+            'type' => 'video',
+            'title' => 'A Talk About Terraform',
+            'slug' => 'a-talk-about-terraform',
+            'url' => 'https://youtube.com/watch?v=dQw4w9WgXcQ',
+            'is_active' => true,
+        ]);
+
+        $response = $this->withHeaders($this->inertiaHeaders())->get('/videos/a-talk-about-terraform');
+
+        $response->assertOk();
+        $page = $response->json();
+
+        $this->assertSame('Media/Detail', $page['component']);
+        $this->assertSame(
+            'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+            $page['props']['item']['embedUrl']
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `mediaItemSlideEmbedUrl()` and `mediaItemYoutubeEmbedUrl()` were bare functions declared inside `routes/web.php`. Production runs `php artisan route:cache` in predeploy, which caches only the route closures, not top-level function declarations in the file — so on a real request the functions were never defined, and any hit on `/slides/{slug}` or `/videos/{slug}` 500'd with "Call to undefined function".
- Moved both into `App\Support\MediaEmbeds` (PSR-4 autoloaded, unaffected by route caching).
- Reproduced locally with `route:cache` active before the fix (confirmed 500), and confirmed 200 after.

## Test plan
- [x] `php artisan test --filter=MediaItemTest` green (8 tests, incl. 2 new route-level tests for slide/video detail embed URLs)
- [x] Reproduced the bug locally with `route:cache` active, confirmed the fix resolves it
- [x] Full suite has 12 pre-existing failures in `ShortLinkTest` unrelated to this change (confirmed present on `main` before this diff too — local test-DB pollution, out of scope here)

Generated with [Claude Code](https://claude.ai/code)