### PR TITLE
Fix slow Google Slides embed load on media detail page

### DIFF
--- a/resources/js/Pages/Media/Detail.tsx
+++ b/resources/js/Pages/Media/Detail.tsx
@@ -1,5 +1,6 @@
 import { Head, Link } from '@inertiajs/react'
-import { ArrowLeft, CalendarDays, ExternalLink, MonitorPlay, Presentation } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { ArrowLeft, CalendarDays, ExternalLink, Loader2, MonitorPlay, Presentation } from 'lucide-react'
 
 type MediaItemDetail = {
   slug: string
@@ -49,6 +50,24 @@ export default function MediaDetailPage({ type, item, related, canonicalUrl }: P
   const title = `${item.title} | Harun R. Rayhan`
   const description = item.summary || copy.fallbackDescription
   const showEmbed = item.embedUrl !== null
+  const [embedLoaded, setEmbedLoaded] = useState(false)
+
+  // Inertia re-renders this same component when navigating between detail
+  // pages (e.g. clicking a related item), so reset the loading state whenever
+  // the embed source changes or the skeleton won't reappear for the new embed.
+  useEffect(() => {
+    setEmbedLoaded(false)
+  }, [item.embedUrl])
+
+  // Warm DNS/TLS to the embed's origins before the iframe element mounts.
+  // Slides serve the embed document from docs.google.com and pull rendered
+  // assets from docs.googleusercontent.com; YouTube serves the player from
+  // youtube-nocookie.com and thumbnails/poster from i.ytimg.com.
+  const preconnectOrigins = showEmbed
+    ? type === 'slide'
+      ? ['https://docs.google.com', 'https://docs.googleusercontent.com']
+      : ['https://www.youtube-nocookie.com', 'https://i.ytimg.com']
+    : []
 
   return (
     <>
@@ -61,6 +80,9 @@ export default function MediaDetailPage({ type, item, related, canonicalUrl }: P
         <meta property="og:url" content={canonicalUrl} />
         {item.thumbnailUrl ? <meta property="og:image" content={item.thumbnailUrl} /> : null}
         <link rel="canonical" href={canonicalUrl} />
+        {preconnectOrigins.map((origin) => (
+          <link key={origin} rel="preconnect" href={origin} />
+        ))}
       </Head>
 
       <div className="pt-24">
@@ -96,8 +118,21 @@ export default function MediaDetailPage({ type, item, related, canonicalUrl }: P
                     title={item.title}
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                     allowFullScreen
+                    onLoad={() => setEmbedLoaded(true)}
                     className="absolute inset-0 h-full w-full border-0"
                   />
+                  <div
+                    aria-hidden="true"
+                    className={`pointer-events-none absolute inset-0 flex items-center justify-center bg-slate-950 transition-opacity duration-500 ${
+                      embedLoaded ? 'opacity-0' : 'opacity-100'
+                    }`}
+                  >
+                    <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-900 via-slate-950 to-slate-800" />
+                    <div className="relative flex items-center gap-2.5 text-sm font-medium text-slate-400">
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      Loading
+                    </div>
+                  </div>
                 </div>
                 <a
                   href={item.shareUrl}


### PR DESCRIPTION
## Problem

On the slide/video detail page (`resources/js/Pages/Media/Detail.tsx`), the embed rendered as a bare dark `bg-slate-950` iframe container with **no loading feedback**. Until Google Slides' (or YouTube's) cross-origin iframe finished loading and painted, the visitor just saw an empty dark box — reading as broken/janky rather than "still loading." Connection setup (DNS/TLS) to Google's servers also didn't begin until the iframe element mounted.

## Changes (scoped to `Detail.tsx` only)

- **Loading state**: track the iframe's load via `useState` + `onLoad`. An animated slate skeleton (`animate-pulse` gradient) with a `Loader2` spinner overlays the container and fades out (`transition-opacity duration-500`) the moment the embed's load event fires. `pointer-events-none` keeps the iframe interactive; a `useEffect` on `item.embedUrl` resets the skeleton when navigating between detail pages (Inertia re-renders the same component).
- **Connection warmup**: `<link rel="preconnect">` added to the page's existing `<Head>` block, per embed type — `docs.google.com` + `docs.googleusercontent.com` for slides, `www.youtube-nocookie.com` + `i.ytimg.com` for videos.
- **`loading="lazy"`**: deliberately not added — the embed is the primary above-the-fold content, so lazy-loading would defer the fetch and fight the preconnect warmup.

The `showEmbed` block is shared by both slides and YouTube videos; both paths use the same skeleton/onLoad. The non-embed fallback branch, related section, and all other pages are untouched.

## Test plan

- Before: blank dark box until Google's/YouTube's iframe paints. After: slate skeleton + spinner visible immediately, swaps to the iframe on load.
- Verify slide detail: skeleton shows, then Google Slides embed appears.
- Verify video detail: skeleton shows, then YouTube (nocookie) player appears; play still works (overlay is `pointer-events-none`).
- Navigate between two related detail pages: skeleton reappears for the second embed.
- `npx tsc --noEmit` clean.
- `npm run build` succeeds.
- `php artisan test --filter=MediaItemTest` — 8 passed (embed URL resolution unchanged; test file not modified).

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded media loading behavior by showing a loading indicator until slides or videos are ready.
  * Loading state now resets correctly when switching between embedded media.
* **Performance**
  * Added connection optimizations for supported slide and video embeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->