### PR TITLE
Style bio Home control as an inline link, not a pill button

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -414,10 +414,12 @@ export default function Bio({
           <div className="absolute right-0 top-0 flex items-center gap-2">
             <Link
               href="/"
-              className="flex h-10 items-center gap-1.5 rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 px-4 font-mono text-xs font-medium uppercase tracking-wider text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
+              className="group inline-flex items-center gap-1.5 rounded-sm font-mono text-xs font-medium uppercase tracking-wider text-[#5b4a3a] transition-colors hover:text-[#b8541f] focus-visible:text-[#b8541f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
             >
-              <ArrowLeft className="h-4 w-4" />
-              Home
+              <ArrowLeft className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-0.5" />
+              <span className="underline decoration-[#5b4a3a]/40 underline-offset-4 transition-colors group-hover:decoration-[#b8541f]">
+                Home
+              </span>
             </Link>
             <button
               type="button"


### PR DESCRIPTION
## What

On the public bio page (`/bio`), the top-right Home control was styled identically to the Subscribe button: a rounded-full pill with a cream fill, border, shadow, and backdrop blur. Per feedback, Home should read as a plain inline link rather than a button.

This strips the pill chrome from Home only. It now renders as an underlined text link (warm brown, with the small left-arrow and the header's mono uppercase treatment) and nudges its arrow left on hover. It stays to the left of Subscribe and vertically centered in the same top-right row. Subscribe stays the filled primary CTA; the share icon is unchanged.

## Test plan

- `npx tsc --noEmit` clean
- `npm run build` succeeds
- Visual check via headless Chrome at desktop (1280px) and mobile (375px):
  - Before: Home rendered as a cream pill button matching Subscribe.
  - After: Home renders as a plain underlined inline link, left of the Subscribe pill, same vertical level.
  - Mobile control-row overflow is pre-existing (confirmed identical before/after); this change actually narrows the row slightly.

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restyled the Bio page’s Home link with a simpler text-based design, animated left-arrow icon, and underline effect.
  * Navigation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->