### PR TITLE
Replace media embed spinner with DevOps holding-pattern loader

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -63,6 +63,69 @@
   animation: accordion-up 0.2s ease-out;
 }
 
+/* Media embed "holding pattern" loading animation (Media/Detail.tsx).
+   A plane traces a DevOps infinity (figure-8) flightpath while the slide/video
+   iframe loads, then breaks out of the loop and departs when it fires onLoad.
+   The offset-path below must stay in sync with HOLDING_PATTERN_PATH in
+   Media/Detail.tsx so the plane rides the visible track. */
+@keyframes holding-orbit {
+  from {
+    offset-distance: 0%;
+  }
+  to {
+    offset-distance: 100%;
+  }
+}
+
+@keyframes flightpath-flow {
+  to {
+    stroke-dashoffset: -160;
+  }
+}
+
+@keyframes plane-depart {
+  0% {
+    transform: translate(0, 0) rotate(45deg) scale(0.9);
+    opacity: 0;
+  }
+  18% {
+    transform: translate(18px, -16px) rotate(45deg) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(180px, -160px) rotate(48deg) scale(1.12);
+    opacity: 0;
+  }
+}
+
+.holding-plane {
+  offset-path: path("M150 75 C150 42 122 20 90 20 C54 20 26 45 26 75 C26 105 54 130 90 130 C122 130 150 108 150 75 C150 42 178 20 210 20 C246 20 274 45 274 75 C274 105 246 130 210 130 C178 130 150 108 150 75 Z");
+  offset-rotate: auto 45deg;
+  animation: holding-orbit 5s linear infinite;
+}
+
+.flightpath-flow {
+  animation: flightpath-flow 3s linear infinite;
+}
+
+.plane-depart {
+  animation: plane-depart 0.7s cubic-bezier(0.45, 0, 0.7, 0.2) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .holding-plane {
+    animation: none;
+    offset-distance: 14%;
+  }
+  .flightpath-flow {
+    animation: none;
+  }
+  .plane-depart {
+    animation: none;
+    opacity: 0;
+  }
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/resources/js/Pages/Media/Detail.tsx
+++ b/resources/js/Pages/Media/Detail.tsx
@@ -1,6 +1,6 @@
 import { Head, Link } from '@inertiajs/react'
 import { useEffect, useState } from 'react'
-import { ArrowLeft, CalendarDays, ExternalLink, Loader2, MonitorPlay, Presentation } from 'lucide-react'
+import { ArrowLeft, CalendarDays, ExternalLink, MonitorPlay, Plane, Presentation } from 'lucide-react'
 
 type MediaItemDetail = {
   slug: string
@@ -26,6 +26,15 @@ type Props = {
   related: RelatedMediaItem[]
   canonicalUrl: string
 }
+
+// Figure-8 / infinity (∞) flightpath for the loading "holding pattern". Traced
+// by the plane via CSS offset-path; kept identical to the `.holding-plane`
+// offset-path in app.css so the plane rides the visible track. Coordinate
+// space is the fixed 300×150 instrument stage below.
+const HOLDING_PATTERN_PATH =
+  'M150 75 C150 42 122 20 90 20 C54 20 26 45 26 75 C26 105 54 130 90 130 C122 130 150 108 150 75 C150 42 178 20 210 20 C246 20 274 45 274 75 C274 105 246 130 210 130 C178 130 150 108 150 75 Z'
+
+const planeGlow = { filter: 'drop-shadow(0 0 6px rgba(251, 191, 36, 0.9))' } as const
 
 const copyByType = {
   slide: {
@@ -123,14 +132,58 @@ export default function MediaDetailPage({ type, item, related, canonicalUrl }: P
                   />
                   <div
                     aria-hidden="true"
-                    className={`pointer-events-none absolute inset-0 flex items-center justify-center bg-slate-950 transition-opacity duration-500 ${
+                    className={`pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-4 bg-slate-950 transition-opacity duration-700 ease-out sm:gap-5 ${
                       embedLoaded ? 'opacity-0' : 'opacity-100'
                     }`}
                   >
-                    <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-900 via-slate-950 to-slate-800" />
-                    <div className="relative flex items-center gap-2.5 text-sm font-medium text-slate-400">
-                      <Loader2 className="h-5 w-5 animate-spin" />
-                      Loading
+                    <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900" />
+
+                    <span className="relative hidden font-mono text-[11px] font-medium uppercase tracking-[0.25em] text-amber-500/80 sm:block">
+                      Holding pattern
+                    </span>
+
+                    {/* Radar-style instrument: a fixed 300×150 stage scaled to fit. The
+                        SVG track and the offset-path plane share this coordinate space,
+                        so they stay aligned as the wrapper scales on small screens. */}
+                    <div className="relative h-[150px] w-[300px] scale-[0.62] sm:scale-100">
+                      <div className="pointer-events-none absolute left-1/2 top-1/2 h-36 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber-500/10 blur-2xl" />
+                      <svg
+                        viewBox="0 0 300 150"
+                        fill="none"
+                        className="absolute inset-0 h-full w-full overflow-visible"
+                        style={{ filter: 'drop-shadow(0 0 5px rgba(251, 191, 36, 0.25))' }}
+                      >
+                        <path d={HOLDING_PATTERN_PATH} stroke="currentColor" strokeWidth={2} className="text-amber-500/20" />
+                        <path
+                          d={HOLDING_PATTERN_PATH}
+                          stroke="currentColor"
+                          strokeWidth={2}
+                          strokeLinecap="round"
+                          strokeDasharray="4 12"
+                          className="flightpath-flow text-amber-400/70"
+                        />
+                      </svg>
+                      {embedLoaded ? (
+                        <div className="plane-depart absolute left-[150px] top-[28px] -ml-2 -mt-2 h-4 w-4 text-amber-300" style={planeGlow}>
+                          <Plane className="h-full w-full" fill="currentColor" strokeWidth={1} />
+                        </div>
+                      ) : (
+                        <div className="holding-plane absolute left-0 top-0 h-4 w-4 text-amber-300" style={planeGlow}>
+                          <Plane className="h-full w-full" fill="currentColor" strokeWidth={1} />
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="relative hidden whitespace-nowrap font-mono text-[10px] uppercase tracking-[0.18em] text-slate-500 sm:block">
+                      Plan · Code · Build · Test · Release · Deploy · Operate · Monitor
+                    </div>
+
+                    <div className="relative flex items-center gap-2.5 px-6 text-center font-mono text-xs text-slate-300 sm:text-sm">
+                      <span className="relative flex h-2 w-2 shrink-0">
+                        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-400 opacity-75" />
+                        <span className="relative inline-flex h-2 w-2 rounded-full bg-amber-500" />
+                      </span>
+                      You&apos;ve entered the holding pattern. Please wait.
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## What

Replaces the generic `Loader2` spinner on the slide/video detail embed (`/slides/{slug}`, `/videos/{slug}`) with an on-brand loading animation.

While the Google Slides / YouTube iframe loads, a plane traces a **DevOps infinity (figure-8 / ∞) flightpath** on the existing dark terminal backdrop. The two lobes read as the well-known DevOps lifecycle loop; marching dashes flow around the track. The moment the iframe fires `onLoad`, the plane breaks out of the loop and streaks off the top-right ("cleared for departure") while the backdrop fades to reveal the now-loaded embed.

It's a mashup of the aviation "please wait, you're in a holding pattern" idea and the DevOps ∞ lifecycle.

### Details
- **CSS-only** motion via CSS Motion Path (`offset-path` + animated `offset-distance`), `offset-rotate: auto` banks the plane through the curve. No new deps (Framer Motion is present but a path-follow is far cleaner in CSS, matching this project's keyframe convention in `app.css`).
- Copy: **"You've entered the holding pattern. Please wait."** with the site's amber ping dot, plus a subtle `Plan · Code · Build · Test · Release · Deploy · Operate · Monitor` legend (sm+ only) to make the DevOps reference explicit.
- Palette matches the hero terminal panel: `slate-950` backdrop, amber accent, `font-mono`.
- `prefers-reduced-motion`: freezes the plane on the track and disables the loop/dash/depart animations, leaving a static frame that just fades on load.
- Preconnect links, the non-embed fallback branch, and the `useEffect` reset on `item.embedUrl` are untouched. Shared by both the slide and video embed paths (no per-type variants needed).

## Test plan
- `npx tsc --noEmit` — clean.
- `npm run build` — succeeds.
- `php artisan test --filter=MediaItemTest` — 8 passed (no backend touched; embed-URL routing intact).
- Rendered the exact markup + CSS in headless Chrome and froze the animation at several `offset-distance` points via negative `animation-delay`:
  - Loop reads clearly as ∞; plane rides the visible track and banks correctly through top/bottom of each lobe and the center crossover.
  - Departure frame shows the plane out of the loop heading up-right off frame.
  - Mobile (~328px `aspect-video`): eyebrow + legend hide, instrument scales down, copy wraps to two lines with nothing clipped.

## Screenshots
Holding (plane on the loop) and departure frames captured during verification — amber ∞ track on slate-950, plane tracing it, `Plan · … · Monitor` legend and the "holding pattern" copy below.

Generated with [Claude Code](https://claude.ai/code)