### PR TITLE
Move Bio "Home" link to the top-left of the header

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -410,42 +410,45 @@ export default function Bio({
           transition={{ duration: 0.6, ease: 'easeOut' }}
           className="relative mx-auto flex min-h-[calc(100svh-6rem)] w-full max-w-xl flex-col items-center pt-12"
         >
-          {/* Subscribe + whole-page share buttons */}
-          <div className="absolute right-0 top-0 flex items-center gap-2">
+          {/* Header: Home sits top-left; Subscribe + whole-page share stay paired top-right */}
+          <div className="absolute inset-x-0 top-0 flex items-center justify-between gap-3">
             <Link
               href="/"
-              className="group inline-flex items-center gap-1.5 rounded-sm font-mono text-xs font-medium uppercase tracking-wider text-[#5b4a3a] transition-colors hover:text-[#b8541f] focus-visible:text-[#b8541f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
+              className="group inline-flex shrink-0 items-center gap-1.5 rounded-sm font-mono text-xs font-medium uppercase tracking-wider text-[#5b4a3a] transition-colors hover:text-[#b8541f] focus-visible:text-[#b8541f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
             >
               <ArrowLeft className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-0.5" />
               <span className="underline decoration-[#5b4a3a]/40 underline-offset-4 transition-colors group-hover:decoration-[#b8541f]">
                 Home
               </span>
             </Link>
-            <button
-              type="button"
-              onClick={() => openPopup('bio-header', 'warm')}
-              className="flex h-10 items-center gap-1.5 rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 px-4 font-mono text-xs font-medium uppercase tracking-wider text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
-            >
-              <Mail className="h-4 w-4" />
-              Subscribe
-            </button>
 
-            <div className="relative" ref={openMenu === 'page' ? menuRef : null}>
+            <div className="flex items-center gap-2">
               <button
                 type="button"
-                onClick={() => setOpenMenu(openMenu === 'page' ? null : 'page')}
-                aria-label="Share this page"
-                aria-haspopup="menu"
-                aria-expanded={openMenu === 'page'}
-                className="flex h-10 w-10 items-center justify-center rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
+                onClick={() => openPopup('bio-header', 'warm')}
+                className="flex h-10 items-center gap-1.5 rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 px-4 font-mono text-xs font-medium uppercase tracking-wider text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
               >
-                <Share2 className="h-4 w-4" />
+                <Mail className="h-4 w-4" />
+                Subscribe
               </button>
-              {openMenu === 'page' && (
-                <div className="absolute right-0 top-full z-30 mt-2">
-                  <ShareSheet title="Harun R. Rayhan" url={pageShareLinkUrl} shareTitle="Harun R. Rayhan" onClose={() => setOpenMenu(null)} />
-                </div>
-              )}
+
+              <div className="relative" ref={openMenu === 'page' ? menuRef : null}>
+                <button
+                  type="button"
+                  onClick={() => setOpenMenu(openMenu === 'page' ? null : 'page')}
+                  aria-label="Share this page"
+                  aria-haspopup="menu"
+                  aria-expanded={openMenu === 'page'}
+                  className="flex h-10 w-10 items-center justify-center rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]"
+                >
+                  <Share2 className="h-4 w-4" />
+                </button>
+                {openMenu === 'page' && (
+                  <div className="absolute right-0 top-full z-30 mt-2">
+                    <ShareSheet title="Harun R. Rayhan" url={pageShareLinkUrl} shareTitle="Harun R. Rayhan" onClose={() => setOpenMenu(null)} />
+                  </div>
+                )}
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## What

Splits the `/bio` page header so **Home** sits on its own at the far **top-left** corner, while **Subscribe** and the whole-page **share icon** stay paired at the far **top-right** corner.

Follow-up to PR #117, which restyled the "Home" control into a plain inline text link (arrow + underlined "HOME") but left it grouped in the top-right cluster next to Subscribe and share.

## How

- Changed the header's outer container from `absolute right-0 top-0 flex items-center gap-2` to `absolute inset-x-0 top-0 flex items-center justify-between gap-3`.
- Home stays as the left child; Subscribe + the share button are wrapped in a right-aligned `flex items-center gap-2` group.
- No restyle of any control: Home keeps its shipped inline-link look (arrow, underline, hover color shift), Subscribe keeps its filled pill, share keeps its circular button. Only layout/position changed.

## Before / After test plan

| | Before | After |
|---|---|---|
| Desktop (1280px) | Home + Subscribe + share all clustered top-right | Home far top-left; Subscribe + share far top-right |
| Mobile (375px) | Home + Subscribe both crammed top-right | Home far top-left; Subscribe + share top-right, one row, no overlap |

Verified:
- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- Headless-Chrome screenshots at 1280px, 375px, and 320px: Home pinned far-left, Subscribe + share pinned far-right, no overlap. The three controls fit on one row at 375px with room to spare (Home ~60px + Subscribe/share ~210px in a ~343px content width).

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LMj5DNQKX71LyUtJamNPRE