### PR TITLE
Fix holding-pattern loader: trace a crossing infinity, not two side-by-side blobs

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -99,7 +99,7 @@
 }
 
 .holding-plane {
-  offset-path: path("M150 75 C150 42 122 20 90 20 C54 20 26 45 26 75 C26 105 54 130 90 130 C122 130 150 108 150 75 C150 42 178 20 210 20 C246 20 274 45 274 75 C274 105 246 130 210 130 C178 130 150 108 150 75 Z");
+  offset-path: path("M150 75 C214 8 274 14 274 75 C274 136 214 142 150 75 C86 8 26 14 26 75 C26 136 86 142 150 75 Z");
   offset-rotate: auto 45deg;
   animation: holding-orbit 5s linear infinite;
 }

--- a/resources/js/Pages/Media/Detail.tsx
+++ b/resources/js/Pages/Media/Detail.tsx
@@ -32,7 +32,7 @@ type Props = {
 // offset-path in app.css so the plane rides the visible track. Coordinate
 // space is the fixed 300×150 instrument stage below.
 const HOLDING_PATTERN_PATH =
-  'M150 75 C150 42 122 20 90 20 C54 20 26 45 26 75 C26 105 54 130 90 130 C122 130 150 108 150 75 C150 42 178 20 210 20 C246 20 274 45 274 75 C274 105 246 130 210 130 C178 130 150 108 150 75 Z'
+  'M150 75 C214 8 274 14 274 75 C274 136 214 142 150 75 C86 8 26 14 26 75 C26 136 86 142 150 75 Z'
 
 const planeGlow = { filter: 'drop-shadow(0 0 6px rgba(251, 191, 36, 0.9))' } as const
 


### PR DESCRIPTION
## What

The DevOps "holding pattern" loader on the slide/video embed pages (`/slides/{slug}`, `/videos/{slug}`, `Media/Detail.tsx`) was designed to show a plane tracing a figure-8 / infinity (∞) flightpath. In production it rendered as **two separate egg-shaped ovals sitting side by side**, not one continuous loop that crosses itself in the middle.

## Root cause (geometry bug)

The path string — shared by the visible SVG track and the plane's `offset-path` — actually drew **two complete closed ovals** that met at only the single center point `(150,75)`. Every control point adjacent to that center sat directly above/below it (`(150,42)` / `(150,108)`, i.e. same `x=150`), which forced **all four tangents at the center to be vertical**. Two ovals meeting with matching vertical tangents just *kiss* at a pinch; they never cross. Hence "two blobs side by side."

A true lemniscate/figure-8 must have its two strands pass through the center on **diagonal** tangents so they form an X.

## Fix

Replaced the two-oval path with a single 4-cubic-Bezier lemniscate whose tangents at the center are diagonal:
- one strand up-right / down-left (~-45°)
- the other up-left / down-right (~-135°)

so the strands genuinely cross at `(150,75)`. Outer lobe caps keep vertical tangents for rounded left/right ends. Same `300×150` coordinate space and center, so nothing else moves.

```
M150 75 C214 8 274 14 274 75 C274 136 214 142 150 75 C86 8 26 14 26 75 C26 136 86 142 150 75 Z
```

Updated in both places that must stay in sync: `HOLDING_PATTERN_PATH` in `Media/Detail.tsx` (the SVG track) and `offset-path` in `.holding-plane` (`app.css`).

Everything else from #119 is untouched: amber glow, marching-dashes track, `offset-rotate: auto` banking, the "You've entered the holding pattern. Please wait." copy, the `Plan · Code · Build · Test · Release · Deploy · Operate · Monitor` legend, the `onLoad` departure animation, `prefers-reduced-motion` handling, and mobile scaling.

## Test plan

Verified visually with headless Chrome, rendering the actual path + `offset-path`/`offset-rotate: auto` mechanism at 16 fixed points around the loop, alongside the old path and a reference ∞:

- **Before:** two ovals meeting at a vertical pinch at center; the track does not cross itself. Matches the reported bug.
- **After:** a single continuous track that visibly crosses itself at the center (forms an X), matching a real ∞. The plane copies ride the crossing curve smoothly and bank through the crossover via `offset-rotate: auto`.
- Numerically confirmed two strands pass through the center region at ≈ -45° and ≈ -135° (a crossing), versus the old path's vertical (±90°) kiss.
- Bounding box `x 26→274, y 27→123`, centered on `(150,75)` — same visual weight as before.

Checks:
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated airplane animations to follow a smooth, symmetric figure-eight path.
  * Applied the refreshed motion to loading and media detail animations while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->