### PR TITLE
Add locale and source tracking to bio links

### DIFF
--- a/app/Http/Controllers/Admin/BioLinkController.php
+++ b/app/Http/Controllers/Admin/BioLinkController.php
@@ -163,6 +163,7 @@ class BioLinkController extends Controller
     {
         return $request->validate([
             'label' => ['required', 'string', 'max:255'],
+            'locale' => ['nullable', 'string', 'in:en,bn'],
             'description' => ['nullable', 'string', 'max:255'],
             'url' => ['required', 'string', 'max:2048'],
             'icon' => ['required', 'string', 'max:60'],
@@ -188,6 +189,7 @@ class BioLinkController extends Controller
         return [
             'id' => $link->id,
             'label' => $link->label,
+            'locale' => $link->locale,
             'description' => $link->description,
             'url' => $link->url,
             'icon' => $link->icon,

--- a/app/Http/Controllers/Admin/BioLinkController.php
+++ b/app/Http/Controllers/Admin/BioLinkController.php
@@ -67,6 +67,7 @@ class BioLinkController extends Controller
     {
         $data = $this->validateData($request);
         unset($data['remove_thumbnail'], $data['thumbnail']); // 'thumbnail' is the raw upload, not a column
+        $data['locale'] = $data['locale'] ?? 'en';
 
         if ($request->hasFile('thumbnail')) {
             $data['thumbnail_path'] = $request->file('thumbnail')->store('bio-thumbnails', 'public');
@@ -92,6 +93,7 @@ class BioLinkController extends Controller
         $data = $this->validateData($request);
         $removeThumbnail = (bool) ($data['remove_thumbnail'] ?? false);
         unset($data['remove_thumbnail'], $data['thumbnail']);
+        $data['locale'] = $data['locale'] ?? 'en';
 
         // A newly uploaded file always wins over "remove"; both replace the
         // old stored file, so the delete only ever targets what's on disk now.

--- a/app/Http/Controllers/Admin/BioLinkController.php
+++ b/app/Http/Controllers/Admin/BioLinkController.php
@@ -59,6 +59,7 @@ class BioLinkController extends Controller
             ]),
             'byCountry' => $this->groupCounts((clone $clicks), 'country'),
             'byReferer' => $this->refererCounts((clone $clicks)),
+            'bySource' => $this->groupCounts((clone $clicks), 'source'),
         ]);
     }
 

--- a/app/Http/Controllers/Admin/ShortLinkController.php
+++ b/app/Http/Controllers/Admin/ShortLinkController.php
@@ -69,6 +69,7 @@ class ShortLinkController extends Controller
             ]),
             'byCountry' => $this->groupCounts((clone $clicks), 'country'),
             'byReferer' => $this->refererCounts((clone $clicks)),
+            'bySource' => $this->groupCounts((clone $clicks), 'source'),
         ]);
     }
 

--- a/app/Models/BioLink.php
+++ b/app/Models/BioLink.php
@@ -14,6 +14,7 @@ class BioLink extends Model
 {
     protected $fillable = [
         'label',
+        'locale',
         'description',
         'url',
         'short_link_id',

--- a/app/Models/BioLinkClick.php
+++ b/app/Models/BioLinkClick.php
@@ -15,6 +15,7 @@ class BioLinkClick extends Model
         'country',
         'user_agent',
         'referer',
+        'source',
     ];
 
     public function bioLink(): BelongsTo

--- a/app/Models/ShortLinkClick.php
+++ b/app/Models/ShortLinkClick.php
@@ -15,6 +15,7 @@ class ShortLinkClick extends Model
         'country',
         'user_agent',
         'referer',
+        'source',
     ];
 
     public function shortLink(): BelongsTo

--- a/database/migrations/2026_08_11_090000_add_locale_to_bio_links_table.php
+++ b/database/migrations/2026_08_11_090000_add_locale_to_bio_links_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bio_links', function (Blueprint $table) {
+            // English is the only content language today, so every existing
+            // row is correctly backfilled as 'en'. A separate Bangla link set
+            // will be tagged 'bn' when it ships.
+            $table->string('locale', 5)->default('en')->after('label');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bio_links', function (Blueprint $table) {
+            $table->dropColumn('locale');
+        });
+    }
+};

--- a/database/migrations/2026_08_11_090100_add_source_to_bio_link_clicks_table.php
+++ b/database/migrations/2026_08_11_090100_add_source_to_bio_link_clicks_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('bio_link_clicks', function (Blueprint $table) {
+            // Explicit tag from a link's ?src= query param (e.g. "twitter",
+            // "linkedin"). Distinct from `referer`: in-app browsers (Instagram,
+            // LinkedIn) often strip or rewrite the Referer header, so this is
+            // the only reliable signal for which platform a click came from.
+            $table->string('source', 60)->nullable()->after('referer');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('bio_link_clicks', function (Blueprint $table) {
+            $table->dropColumn('source');
+        });
+    }
+};

--- a/database/migrations/2026_08_11_090200_add_source_to_short_link_clicks_table.php
+++ b/database/migrations/2026_08_11_090200_add_source_to_short_link_clicks_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('short_link_clicks', function (Blueprint $table) {
+            // Explicit tag from a link's ?src= query param, same purpose as
+            // bio_link_clicks.source -- see that migration for why it exists
+            // alongside `referer`.
+            $table->string('source', 60)->nullable()->after('referer');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('short_link_clicks', function (Blueprint $table) {
+            $table->dropColumn('source');
+        });
+    }
+};

--- a/resources/js/Pages/Admin/Bio/Analytics.tsx
+++ b/resources/js/Pages/Admin/Bio/Analytics.tsx
@@ -32,6 +32,7 @@ interface Props {
   byLink: LinkRow[]
   byCountry: GroupRow[]
   byReferer: GroupRow[]
+  bySource: GroupRow[]
 }
 
 const RANGES = [7, 30, 90]
@@ -96,6 +97,7 @@ export default function Analytics({
   byLink,
   byCountry,
   byReferer,
+  bySource,
 }: Props) {
   const [hover, setHover] = useState<DailyPoint | null>(null)
 
@@ -201,7 +203,7 @@ export default function Analytics({
             )}
           </section>
 
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
             <RankedList
               title="Top countries"
               rows={byCountry}
@@ -219,6 +221,13 @@ export default function Analytics({
               rows={byReferer}
               empty="No referrer data yet."
               renderLabel={(host) => host}
+            />
+
+            <RankedList
+              title="Top sources"
+              rows={bySource}
+              empty="No source data yet. Sources are tagged via a share link's ?src= parameter."
+              renderLabel={(source) => source}
             />
           </div>
 

--- a/resources/js/Pages/Admin/Bio/Create.tsx
+++ b/resources/js/Pages/Admin/Bio/Create.tsx
@@ -5,6 +5,7 @@ import BioLinkForm, { type BioLinkFormData } from './Partials/BioLinkForm'
 export default function Create() {
   const { data, setData, post, processing, errors } = useForm<BioLinkFormData>({
     label: '',
+    locale: 'en',
     description: '',
     url: '',
     icon: 'link',

--- a/resources/js/Pages/Admin/Bio/Edit.tsx
+++ b/resources/js/Pages/Admin/Bio/Edit.tsx
@@ -5,6 +5,7 @@ import BioLinkForm, { type BioLinkFormData } from './Partials/BioLinkForm'
 interface BioLinkRecord {
   id: number
   label: string
+  locale: string
   description: string | null
   url: string
   icon: string
@@ -22,6 +23,7 @@ interface BioLinkRecord {
 export default function Edit({ link }: { link: BioLinkRecord }) {
   const { data, setData, post, transform, processing, errors } = useForm<BioLinkFormData>({
     label: link.label,
+    locale: link.locale ?? 'en',
     description: link.description ?? '',
     url: link.url,
     icon: link.icon ?? 'link',

--- a/resources/js/Pages/Admin/Bio/Partials/BioLinkForm.tsx
+++ b/resources/js/Pages/Admin/Bio/Partials/BioLinkForm.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 export interface BioLinkFormData {
   label: string
+  locale: string
   description: string
   url: string
   icon: string
@@ -98,6 +99,21 @@ export default function BioLinkForm({
           required
         />
         <InputError message={errors.label} className="mt-2" />
+      </div>
+
+      <div>
+        <InputLabel htmlFor="locale" value="Content language" />
+        <select
+          id="locale"
+          value={data.locale}
+          onChange={(e) => setData('locale', e.target.value)}
+          className="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        >
+          <option value="en">English</option>
+          <option value="bn">Bangla</option>
+        </select>
+        <p className="mt-1 text-xs text-gray-500">Which bio page this link belongs to.</p>
+        <InputError message={errors.locale} className="mt-2" />
       </div>
 
       <div>

--- a/resources/js/Pages/Admin/Short/Analytics.tsx
+++ b/resources/js/Pages/Admin/Short/Analytics.tsx
@@ -39,6 +39,7 @@ interface Props {
   byLink: LinkRow[]
   byCountry: GroupRow[]
   byReferer: GroupRow[]
+  bySource: GroupRow[]
 }
 
 const RANGES = [7, 30, 90]
@@ -109,6 +110,7 @@ export default function Analytics({
   byLink,
   byCountry,
   byReferer,
+  bySource,
 }: Props) {
   const [hover, setHover] = useState<DailyPoint | null>(null)
 
@@ -241,7 +243,7 @@ export default function Analytics({
             )}
           </section>
 
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
             <RankedList
               title="Top countries"
               rows={byCountry}
@@ -259,6 +261,13 @@ export default function Analytics({
               rows={byReferer}
               empty="No referrer data yet."
               renderLabel={(host) => host}
+            />
+
+            <RankedList
+              title="Top sources"
+              rows={bySource}
+              empty="No source data yet. Sources are tagged via a share link's ?src= parameter."
+              renderLabel={(source) => source}
             />
           </div>
 

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -65,13 +65,16 @@ const DECLARED_TABS: { slug: string; label: string; Icon: BioIcon }[] = [
   { slug: 'others', label: 'Others', Icon: MoreHorizontal },
 ]
 
-/** POST a click event to the server (fire-and-forget with keepalive). */
+/** POST a click event to the server (fire-and-forget with keepalive). The
+ *  optional ?src= on the page URL (set by a platform-specific share link)
+ *  survives in-app browsers that strip the Referer header. */
 const trackClick = (id: number) => {
   try {
+    const src = new URLSearchParams(window.location.search).get('src')
     fetch('/bio/click', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-      body: JSON.stringify({ id }),
+      body: JSON.stringify({ id, src }),
       keepalive: true,
     })
   } catch {

--- a/routes/web.php
+++ b/routes/web.php
@@ -124,9 +124,14 @@ Route::middleware(['auth', 'verified', 'role:admin'])
         Route::delete('/{shortLink}', [ShortLinkController::class, 'destroy'])->name('destroy');
     });
 
+// Shared by the click-recording routes below: a raw 'src' value (query or
+// body) is untrusted visitor input, so we normalize defensively rather than
+// reject it — bad input just means no source tag, never a dropped click.
+$normalizeClickSource = fn ($value): ?string => is_string($value) && $value !== '' ? mb_substr($value, 0, 60) : null;
+
 // Public short-link redirect + click tracking (no auth needed). 302 so
 // browsers/CDNs never cache the redirect and skip recording a hit.
-Route::get('/s/{code}', function (string $code, Request $request, CountryResolver $countries) {
+Route::get('/s/{code}', function (string $code, Request $request, CountryResolver $countries) use ($normalizeClickSource) {
     $link = ShortLink::query()->active()->where('code', $code)->first();
 
     abort_unless($link, 404);
@@ -139,7 +144,7 @@ Route::get('/s/{code}', function (string $code, Request $request, CountryResolve
         'country' => $country,
         'user_agent' => $request->userAgent(),
         'referer' => $request->header('referer'),
-        'source' => is_string($src = $request->query('src')) && $src !== '' ? mb_substr($src, 0, 60) : null,
+        'source' => $normalizeClickSource($request->query('src')),
     ]);
 
     return redirect()->away($link->resolveDestination($country), 302);
@@ -190,10 +195,9 @@ Route::get('/bio', function (Request $request, CountryResolver $countries) {
 });
 
 // Click tracking for bio links (no auth needed)
-Route::post('/bio/click', function (Request $request, CountryResolver $countries) {
+Route::post('/bio/click', function (Request $request, CountryResolver $countries) use ($normalizeClickSource) {
     $data = $request->validate([
         'id' => ['required', 'integer', 'exists:bio_links,id'],
-        'src' => ['nullable', 'string', 'max:60'],
     ]);
 
     App\Models\BioLinkClick::create([
@@ -202,7 +206,7 @@ Route::post('/bio/click', function (Request $request, CountryResolver $countries
         'country' => $countries->resolve($request->ip()),
         'user_agent' => $request->userAgent(),
         'referer' => $request->header('referer'),
-        'source' => $data['src'] ?? null,
+        'source' => $normalizeClickSource($request->input('src')),
     ]);
 
     return response()->noContent();

--- a/routes/web.php
+++ b/routes/web.php
@@ -193,6 +193,7 @@ Route::get('/bio', function (Request $request, CountryResolver $countries) {
 Route::post('/bio/click', function (Request $request, CountryResolver $countries) {
     $data = $request->validate([
         'id' => ['required', 'integer', 'exists:bio_links,id'],
+        'src' => ['nullable', 'string', 'max:60'],
     ]);
 
     App\Models\BioLinkClick::create([
@@ -201,6 +202,7 @@ Route::post('/bio/click', function (Request $request, CountryResolver $countries
         'country' => $countries->resolve($request->ip()),
         'user_agent' => $request->userAgent(),
         'referer' => $request->header('referer'),
+        'source' => $data['src'] ?? null,
     ]);
 
     return response()->noContent();

--- a/routes/web.php
+++ b/routes/web.php
@@ -139,6 +139,7 @@ Route::get('/s/{code}', function (string $code, Request $request, CountryResolve
         'country' => $country,
         'user_agent' => $request->userAgent(),
         'referer' => $request->header('referer'),
+        'source' => is_string($src = $request->query('src')) && $src !== '' ? mb_substr($src, 0, 60) : null,
     ]);
 
     return redirect()->away($link->resolveDestination($country), 302);

--- a/tests/Feature/BioLinkAnalyticsTest.php
+++ b/tests/Feature/BioLinkAnalyticsTest.php
@@ -147,4 +147,24 @@ class BioLinkAnalyticsTest extends TestCase
 
         $this->assertSame('linkedin', \App\Models\BioLinkClick::first()->source);
     }
+
+    public function test_it_reports_clicks_by_source(): void
+    {
+        $link = $this->link();
+
+        $this->click($link, ['source' => 'twitter']);
+        $this->click($link, ['source' => 'twitter']);
+        $this->click($link, ['source' => 'linkedin']);
+        $this->click($link); // no source -- excluded from the breakdown
+
+        $props = $this->actingAs($this->admin())
+            ->get('/admin/bio/analytics')
+            ->assertOk()
+            ->viewData('page')['props'];
+
+        $bySource = collect($props['bySource'])->pluck('clicks', 'key');
+        $this->assertSame(2, $bySource['twitter']);
+        $this->assertSame(1, $bySource['linkedin']);
+        $this->assertArrayNotHasKey('', $bySource);
+    }
 }

--- a/tests/Feature/BioLinkAnalyticsTest.php
+++ b/tests/Feature/BioLinkAnalyticsTest.php
@@ -138,4 +138,13 @@ class BioLinkAnalyticsTest extends TestCase
 
         $this->assertDatabaseHas('bio_link_clicks', ['bio_link_id' => $link->id, 'source' => 'twitter']);
     }
+
+    public function test_bio_click_records_an_optional_src_param(): void
+    {
+        $link = $this->link();
+
+        $this->postJson('/bio/click', ['id' => $link->id, 'src' => 'linkedin']);
+
+        $this->assertSame('linkedin', \App\Models\BioLinkClick::first()->source);
+    }
 }

--- a/tests/Feature/BioLinkAnalyticsTest.php
+++ b/tests/Feature/BioLinkAnalyticsTest.php
@@ -129,4 +129,13 @@ class BioLinkAnalyticsTest extends TestCase
         $this->assertSame(30, $props['days']);
         $this->assertCount(30, $props['daily']);
     }
+
+    public function test_source_is_stored_on_a_click(): void
+    {
+        $link = $this->link();
+
+        $this->click($link, ['source' => 'twitter']);
+
+        $this->assertDatabaseHas('bio_link_clicks', ['bio_link_id' => $link->id, 'source' => 'twitter']);
+    }
 }

--- a/tests/Feature/BioLinkAnalyticsTest.php
+++ b/tests/Feature/BioLinkAnalyticsTest.php
@@ -148,6 +148,30 @@ class BioLinkAnalyticsTest extends TestCase
         $this->assertSame('linkedin', \App\Models\BioLinkClick::first()->source);
     }
 
+    public function test_an_overlong_src_on_bio_click_still_records_a_truncated_source(): void
+    {
+        $link = $this->link();
+
+        $this->postJson('/bio/click', ['id' => $link->id, 'src' => str_repeat('a', 100)])
+            ->assertNoContent();
+
+        $click = BioLinkClick::first();
+        $this->assertNotNull($click);
+        $this->assertSame(str_repeat('a', 60), $click->source);
+    }
+
+    public function test_a_malformed_array_src_on_bio_click_still_records_a_null_source(): void
+    {
+        $link = $this->link();
+
+        $this->postJson('/bio/click', ['id' => $link->id, 'src' => ['x']])
+            ->assertNoContent();
+
+        $click = BioLinkClick::first();
+        $this->assertNotNull($click);
+        $this->assertNull($click->source);
+    }
+
     public function test_it_reports_clicks_by_source(): void
     {
         $link = $this->link();

--- a/tests/Feature/BioLinkThumbnailTest.php
+++ b/tests/Feature/BioLinkThumbnailTest.php
@@ -177,6 +177,14 @@ class BioLinkThumbnailTest extends TestCase
         $this->assertSame('bn', $link->fresh()->locale);
     }
 
+    public function test_an_empty_string_locale_still_creates_with_the_english_default(): void
+    {
+        $response = $this->actingAs($this->admin())->post('/admin/bio', $this->payload(['locale' => '']));
+
+        $response->assertRedirect(route('admin.bio.index'));
+        $this->assertDatabaseHas('bio_links', ['label' => 'Portfolio', 'locale' => 'en']);
+    }
+
     public function test_an_invalid_locale_is_rejected(): void
     {
         $response = $this->actingAs($this->admin())->post('/admin/bio', $this->payload(['locale' => 'fr']));

--- a/tests/Feature/BioLinkThumbnailTest.php
+++ b/tests/Feature/BioLinkThumbnailTest.php
@@ -162,4 +162,26 @@ class BioLinkThumbnailTest extends TestCase
 
         $this->assertDatabaseHas('bio_links', ['label' => 'Portfolio', 'locale' => 'en']);
     }
+
+    public function test_locale_can_be_set_to_bangla_on_update(): void
+    {
+        $this->actingAs($this->admin())->post('/admin/bio', $this->payload());
+        $link = \App\Models\BioLink::first();
+
+        $this->actingAs($this->admin())
+            ->post("/admin/bio/{$link->id}", array_merge($this->payload(), [
+                '_method' => 'put',
+                'locale' => 'bn',
+            ]));
+
+        $this->assertSame('bn', $link->fresh()->locale);
+    }
+
+    public function test_an_invalid_locale_is_rejected(): void
+    {
+        $response = $this->actingAs($this->admin())->post('/admin/bio', $this->payload(['locale' => 'fr']));
+
+        $response->assertSessionHasErrors('locale');
+        $this->assertDatabaseCount('bio_links', 0);
+    }
 }

--- a/tests/Feature/BioLinkThumbnailTest.php
+++ b/tests/Feature/BioLinkThumbnailTest.php
@@ -155,4 +155,11 @@ class BioLinkThumbnailTest extends TestCase
         $this->assertTrue($link['featured']);
         $this->assertStringContainsString('bio-thumbnails/hero.jpg', $link['thumbnail_url']);
     }
+
+    public function test_a_new_bio_link_defaults_to_english_locale(): void
+    {
+        $this->actingAs($this->admin())->post('/admin/bio', $this->payload());
+
+        $this->assertDatabaseHas('bio_links', ['label' => 'Portfolio', 'locale' => 'en']);
+    }
 }

--- a/tests/Feature/ShortLinkTest.php
+++ b/tests/Feature/ShortLinkTest.php
@@ -170,4 +170,22 @@ class ShortLinkTest extends TestCase
         $this->assertSame(1, ShortLink::count());
         $this->assertSame($existing->code, ShortLink::first()->code);
     }
+
+    public function test_a_src_query_param_is_recorded_as_the_click_source(): void
+    {
+        $link = ShortLink::create(['destination_url' => 'https://example.com/target']);
+
+        $this->get("/s/{$link->code}?src=twitter")->assertRedirect('https://example.com/target');
+
+        $this->assertSame('twitter', ShortLinkClick::first()->source);
+    }
+
+    public function test_a_missing_src_query_param_leaves_source_null(): void
+    {
+        $link = ShortLink::create(['destination_url' => 'https://example.com/target']);
+
+        $this->get("/s/{$link->code}")->assertRedirect('https://example.com/target');
+
+        $this->assertNull(ShortLinkClick::first()->source);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a `locale` field to bio links (admin form + DB column, defaults to `en`)
- Adds a `source` click-tag captured via `?src=` on both `/s/{code}` and `/bio/click`, with shared defensive normalization (truncate/reject malformed input without dropping the click)
- Surfaces a "clicks by source" breakdown on the bio and short-link analytics dashboards

## Test plan
- [x] Full plan-scoped test suite green (`BioLinkAnalyticsTest`, `BioLinkThumbnailTest`, `ShortLinkTest` src-specific cases, etc.)
- [x] Task-by-task and final whole-branch review clean (subagent-driven-development)
- [ ] Manual admin-panel verification blocked in this environment (credential entry disallowed by tool policy) — recommend a quick manual click-through before merge

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English and Bangla locale selection for BioLinks, with English as the default.
  * Added click-source tracking for BioLinks and Short Links, including support for optional URL source parameters.
  * Added “Top sources” breakdowns to BioLink and Short Link analytics.
* **Bug Fixes**
  * Invalid or overly long source values are safely normalized before being recorded.
  * Unsupported BioLink locales are rejected with validation feedback.
* **Tests**
  * Added coverage for locale behavior, source tracking, validation, and analytics aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->