### PR TITLE
Fix test-suite DB isolation and staleness bugs

### DIFF
--- a/resources/blog/posts/test-fixture-permanent-draft.md
+++ b/resources/blog/posts/test-fixture-permanent-draft.md
@@ -1,0 +1,14 @@
+---
+title: "Test Fixture: Permanent Draft Post"
+slug: "test-fixture-permanent-draft"
+draft: true
+draftToken: "0af04d79dcd1e37ac9f5723c01ee4d0f"
+brief: "Fixture post used by the test suite to exercise draft-post behavior. Never published; publishedAt is set far in the future so blog:publish-scheduled always skips it."
+publishedAt: "2099-01-01T00:00:00.000Z"
+readTimeInMinutes: 1
+reactionCount: 0
+responseCount: 0
+replyCount: 0
+tags: []
+---
+This post exists only so the test suite has a stable draft fixture that will not get auto-published. Do not edit publishedAt or remove draft: true.

--- a/tests/Feature/AdminPanelTest.php
+++ b/tests/Feature/AdminPanelTest.php
@@ -17,6 +17,7 @@ class AdminPanelTest extends TestCase
     {
         $user = User::factory()->create([
             'email_verified_at' => now(),
+            'role' => 'admin',
         ]);
 
         $this->actingAs($user)

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -27,7 +27,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertRedirect(route('blog.index', absolute: false));
     }
 
     public function test_users_can_not_authenticate_with_invalid_password(): void

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -26,6 +26,6 @@ class RegistrationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertRedirect(route('blog.index', absolute: false));
     }
 }

--- a/tests/Feature/BlogCommentTest.php
+++ b/tests/Feature/BlogCommentTest.php
@@ -62,7 +62,7 @@ class BlogCommentTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $response = $this->actingAs($user)->post('/blog/how-i-make-ai-coding-agents-safe-in-a-real-aws-codebase/comments', [
+        $response = $this->actingAs($user)->post('/blog/test-fixture-permanent-draft/comments', [
             'content' => 'This is a draft comment.',
         ]);
 

--- a/tests/Feature/BlogSeoTest.php
+++ b/tests/Feature/BlogSeoTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class BlogSeoTest extends TestCase
 {
+    use RefreshDatabase;
+
     #[Test]
     public function it_exposes_the_blog_index_in_the_sitemap_without_a_trailing_slash(): void
     {
@@ -21,13 +24,13 @@ class BlogSeoTest extends TestCase
     #[Test]
     public function it_keeps_draft_posts_out_of_the_blog_index_and_sitemap(): void
     {
-        $draftUrl = rtrim(config('app.url', url('/')), '/') . '/blog/how-i-make-ai-coding-agents-safe-in-a-real-aws-codebase';
+        $draftUrl = rtrim(config('app.url', url('/')), '/') . '/blog/test-fixture-permanent-draft';
 
         $indexResponse = $this->get('/blog');
         $sitemapResponse = $this->get('/sitemap.xml');
 
         $indexResponse->assertOk();
-        $indexResponse->assertDontSee('How I Make AI Coding Agents Safe in a Real AWS Codebase', false);
+        $indexResponse->assertDontSee('Test Fixture: Permanent Draft Post', false);
 
         $sitemapResponse->assertOk();
         $sitemapResponse->assertDontSee('<loc>' . $draftUrl . '</loc>', false);
@@ -36,7 +39,7 @@ class BlogSeoTest extends TestCase
     #[Test]
     public function it_hides_draft_posts_behind_a_private_preview_link(): void
     {
-        $draftSlug = 'llm-observability-langfuse-lambda-cloudwatch';
+        $draftSlug = 'test-fixture-permanent-draft';
         $draftUrl = rtrim(config('app.url', url('/')), '/') . '/blog/' . $draftSlug;
         $previewUrl = $draftUrl . '/draft/0af04d79dcd1e37ac9f5723c01ee4d0f';
 
@@ -60,7 +63,7 @@ class BlogSeoTest extends TestCase
     #[Test]
     public function it_marks_draft_posts_as_noindex_when_rendered_directly(): void
     {
-        $response = $this->get('/blog/how-i-make-ai-coding-agents-safe-in-a-real-aws-codebase');
+        $response = $this->get('/blog/test-fixture-permanent-draft');
 
         $response->assertNotFound();
     }


### PR DESCRIPTION
## Summary
- Add `RefreshDatabase` to `BlogSeoTest` to stop leaked `ShortLink` rows from polluting other tests
- Replace time-decaying draft-post fixtures with a permanent draft post (`publishedAt` in 2099) across `BlogSeoTest`/`BlogCommentTest`
- Update login/registration/admin-panel tests to match the `role:admin` gate added 2026-07-21

## Test plan
- [x] `php artisan test` — 144 passed, 0 failures, 453 assertions

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Experience**
  - Successful sign-ins and registrations now redirect to the blog landing page.
  - Draft blog posts remain unavailable to visitors, including for comment submission.
  - Blog SEO behavior continues to use stable draft content for consistent titles and metadata.

- **Tests**
  - Expanded coverage for administrator access, draft visibility, comment restrictions, authentication redirects, and blog SEO behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->