### PR TITLE
feat: public API for short links + QR codes with Sanctum API keys and rate limiting

### DIFF
--- a/app/Http/Controllers/Admin/ApiKeyController.php
+++ b/app/Http/Controllers/Admin/ApiKeyController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\PersonalAccessToken;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ApiKeyController extends Controller
+{
+    /**
+     * The acting admin's own keys. There's no way to show a plaintext token
+     * again once created, so this only ever exposes metadata.
+     */
+    public function index(Request $request): Response
+    {
+        return Inertia::render('Admin/ApiKeys/Index', [
+            'tokens' => $request->user()->tokens()
+                ->orderByDesc('id')
+                ->get()
+                ->map(fn (PersonalAccessToken $token) => $this->toPayload($token))
+                ->all(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'rate_limit_per_minute' => ['nullable', 'integer', 'min:1'],
+            'rate_limit_per_day' => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        $newToken = $request->user()->createToken($data['name'], ['*']);
+
+        $newToken->accessToken->forceFill([
+            'rate_limit_per_minute' => $data['rate_limit_per_minute'] ?? null,
+            'rate_limit_per_day' => $data['rate_limit_per_day'] ?? null,
+        ])->save();
+
+        // Plaintext token is only ever available right here, right now --
+        // Sanctum stores just the hash. Flashed once for the frontend to
+        // show in a copy-to-clipboard box, then it's gone for good.
+        return redirect()->route('admin.api-keys.index')->with('flash', [
+            'type' => 'success',
+            'message' => 'API key created. Copy it now, it will not be shown again.',
+            'token' => $newToken->plainTextToken,
+        ]);
+    }
+
+    public function destroy(Request $request, string $id): RedirectResponse
+    {
+        $deleted = $request->user()->tokens()->where('id', $id)->delete();
+
+        abort_unless($deleted, 404);
+
+        return redirect()->route('admin.api-keys.index')->with('flash', [
+            'type' => 'success',
+            'message' => 'API key revoked.',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toPayload(PersonalAccessToken $token): array
+    {
+        return [
+            'id' => $token->id,
+            'name' => $token->name,
+            'rate_limit_per_minute' => $token->rate_limit_per_minute,
+            'rate_limit_per_day' => $token->rate_limit_per_day,
+            'last_used_at' => $token->last_used_at?->toIso8601String(),
+            'created_at' => $token->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/QrCodeController.php
+++ b/app/Http/Controllers/Api/QrCodeController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Writer\PngWriter;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class QrCodeController extends Controller
+{
+    /**
+     * Generate a QR code for arbitrary text/URL content. JSON with a
+     * data-uri by default; ?format=png returns raw PNG bytes instead, so
+     * the same endpoint can back an <img src> or a direct download.
+     */
+    public function store(Request $request): JsonResponse|Response
+    {
+        $data = $request->validate([
+            'content' => ['required', 'string', 'max:2000'],
+        ]);
+
+        $result = (new Builder(writer: new PngWriter))->build(data: $data['content']);
+
+        if ($request->query('format') === 'png') {
+            return response($result->getString(), 200, [
+                'Content-Type' => 'image/png',
+            ]);
+        }
+
+        return response()->json([
+            'qr_code' => $result->getDataUri(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/ShortLinkController.php
+++ b/app/Http/Controllers/Api/ShortLinkController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ShortLink;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ShortLinkController extends Controller
+{
+    /**
+     * Create (or, per the existing url_hash dedup rule, reuse) a short link
+     * for destination_url. The token owner is stamped as the link's user_id
+     * only the first time it's actually created -- a reused link keeps
+     * whichever owner (or nobody) it already had.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'destination_url' => ['required', 'url', 'max:2048'],
+            'title' => ['nullable', 'string', 'max:255'],
+            'expires_at' => ['nullable', 'date', 'after:now'],
+        ]);
+
+        $link = ShortLink::getOrCreateForUrl($data['destination_url'], $data['title'] ?? null);
+
+        if (! $link) {
+            return response()->json([
+                'message' => 'destination_url must be a shortenable http(s) URL.',
+                'errors' => ['destination_url' => ['destination_url must be a shortenable http(s) URL.']],
+            ], 422);
+        }
+
+        if ($link->wasRecentlyCreated) {
+            $link->user_id = $request->user()->id;
+
+            if (! empty($data['expires_at'])) {
+                $link->expires_at = $data['expires_at'];
+            }
+
+            $link->save();
+
+            // Eloquent doesn't repopulate DB column defaults (e.g. is_active)
+            // into the in-memory model after the initial INSERT, so pull the
+            // row back to get the true persisted state for the response.
+            $link->refresh();
+        }
+
+        return response()->json($this->toPayload($link), 201);
+    }
+
+    /**
+     * The caller's own links, paginated -- or every link, for an admin key.
+     */
+    public function index(Request $request): AnonymousResourceCollection|JsonResponse
+    {
+        $query = ShortLink::query()->orderByDesc('id');
+
+        if (! $request->user()->isAdmin()) {
+            $query->where('user_id', $request->user()->id);
+        }
+
+        $links = $query->paginate();
+        $links->getCollection()->transform(fn (ShortLink $link) => $this->toPayload($link));
+
+        return response()->json($links);
+    }
+
+    public function show(Request $request, string $code): JsonResponse
+    {
+        $link = $this->findOrFail($code);
+
+        return response()->json($this->toPayload($link) + [
+            'click_count' => $link->clicks()->count(),
+        ]);
+    }
+
+    public function deactivate(Request $request, string $code): JsonResponse
+    {
+        $link = $this->findOrFail($code);
+        $this->authorizeModification($request, $link);
+
+        $link->update(['is_active' => false]);
+
+        return response()->json($this->toPayload($link));
+    }
+
+    public function destroy(Request $request, string $code): JsonResponse
+    {
+        $link = $this->findOrFail($code);
+        $this->authorizeModification($request, $link);
+
+        $link->delete();
+
+        return response()->json(null, 204);
+    }
+
+    private function findOrFail(string $code): ShortLink
+    {
+        $link = ShortLink::where('code', $code)->first();
+
+        abort_unless($link, 404);
+
+        return $link;
+    }
+
+    /**
+     * Owner or admin only. A null-owner link (legacy/admin-created) is
+     * admin-only, since nobody but an admin ever "owns" it.
+     */
+    private function authorizeModification(Request $request, ShortLink $link): void
+    {
+        $user = $request->user();
+
+        abort_unless($link->user_id === $user->id || $user->isAdmin(), 403);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toPayload(ShortLink $link): array
+    {
+        return [
+            'code' => $link->code,
+            'short_url' => $link->short_url,
+            'destination_url' => $link->destination_url,
+            'title' => $link->title,
+            'is_active' => (bool) $link->is_active,
+            'expires_at' => $link->expires_at?->toIso8601String(),
+            'qr_code_url' => route('api.v1.qr-codes.store', [
+                'content' => $link->short_url,
+                'format' => 'png',
+            ]),
+        ];
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -40,6 +40,12 @@ class HandleInertiaRequests extends Middleware
             ],
             'caseStudiesByService' => $byService,
             'featuredCaseStudies' => $caseStudies->featured(3),
+            // Pages already read usePage().props.flash (Contact.tsx, Bio.tsx)
+            // for the ->with('flash', [...]) convention used across admin
+            // controllers, but nothing was actually sharing it as an Inertia
+            // prop -- add it here so that convention works everywhere,
+            // including the new admin/api-keys "here's your token" flash.
+            'flash' => fn () => $request->session()->get('flash'),
         ];
     }
 }

--- a/app/Models/PersonalAccessToken.php
+++ b/app/Models/PersonalAccessToken.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Sanctum\PersonalAccessToken as SanctumPersonalAccessToken;
+
+class PersonalAccessToken extends SanctumPersonalAccessToken
+{
+    protected $fillable = [
+        'name',
+        'token',
+        'abilities',
+        'expires_at',
+        'rate_limit_per_minute',
+        'rate_limit_per_day',
+    ];
+
+    protected $casts = [
+        'abilities' => 'array',
+        'last_used_at' => 'datetime',
+        'expires_at' => 'datetime',
+        'rate_limit_per_minute' => 'integer',
+        'rate_limit_per_day' => 'integer',
+    ];
+}

--- a/app/Models/ShortLink.php
+++ b/app/Models/ShortLink.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -12,6 +13,7 @@ class ShortLink extends Model
 {
     protected $fillable = [
         'code',
+        'user_id',
         'destination_url',
         'country_overrides',
         'url_hash',
@@ -177,5 +179,10 @@ class ShortLink extends Model
     public function clicks(): HasMany
     {
         return $this->hasMany(ShortLinkClick::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,10 +2,15 @@
 
 namespace App\Providers;
 
+use App\Models\PersonalAccessToken;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Sanctum\Sanctum;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -36,5 +41,20 @@ class AppServiceProvider extends ServiceProvider
         if ($path = env('VIEW_COMPILED_PATH')) {
             View::addNamespace('views', $path);
         }
+
+        Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
+
+        // Per-token API rate limits, keyed by the token id (never by IP) so
+        // rotating keys can't be used to dodge the limit. Unauthenticated
+        // requests never reach this limiter -- auth:sanctum rejects them
+        // with a 401 first in the api/v1 middleware group.
+        RateLimiter::for('api-key', function (Request $request) {
+            $token = $request->user()?->currentAccessToken();
+
+            return [
+                Limit::perMinute($token?->rate_limit_per_minute ?? 60)->by('token:'.$token?->id),
+                Limit::perDay($token?->rate_limit_per_day ?? 2000)->by('token:'.$token?->id),
+            ];
+        });
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4",
+        "endroid/qr-code": "^6.1",
         "geoip2/geoip2": "^3.4",
         "inertiajs/inertia-laravel": "^3.1.0",
         "laravel/framework": "^13.11.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "254226e7daea92aa37c7eae442736dea",
+    "content-hash": "20d4a97ef8836e044597f600a431b1a9",
     "packages": [
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || ^11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "spatie/pixelmatch-php": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.1.1"
+            },
+            "time": "2026-04-05T21:06:35+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.8",
@@ -206,6 +261,56 @@
                 }
             ],
             "time": "2026-07-18T12:35:13+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
+            },
+            "time": "2025-09-16T12:23:56+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -579,6 +684,78 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "endroid/qr-code",
+            "version": "6.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/endroid/qr-code.git",
+                "reference": "5fa534856ed95649d67c0eab0cabc03ab1d8e0e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/5fa534856ed95649d67c0eab0cabc03ab1d8e0e2",
+                "reference": "5fa534856ed95649d67c0eab0cabc03ab1d8e0e2",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^3.0",
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "endroid/quality": "dev-main",
+                "ext-gd": "*",
+                "khanamiryan/qrcode-detector-decoder": "^2.0.3",
+                "setasign/fpdf": "^1.8.2"
+            },
+            "suggest": {
+                "ext-gd": "Enables you to write PNG images",
+                "khanamiryan/qrcode-detector-decoder": "Enables you to use the image validator",
+                "roave/security-advisories": "Makes sure package versions with known security issues are not installed",
+                "setasign/fpdf": "Enables you to use the PDF writer"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Endroid\\QrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeroen van den Enden",
+                    "email": "info@endroid.nl"
+                }
+            ],
+            "description": "Endroid QR Code",
+            "homepage": "https://github.com/endroid/qr-code",
+            "keywords": [
+                "code",
+                "endroid",
+                "php",
+                "qr",
+                "qrcode"
+            ],
+            "support": {
+                "issues": "https://github.com/endroid/qr-code/issues",
+                "source": "https://github.com/endroid/qr-code/tree/6.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/endroid",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-05T07:01:58+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/database/migrations/2026_08_12_125203_create_personal_access_tokens_table.php
+++ b/database/migrations/2026_08_12_125203_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/database/migrations/2026_08_12_190000_add_rate_limits_to_personal_access_tokens_table.php
+++ b/database/migrations/2026_08_12_190000_add_rate_limits_to_personal_access_tokens_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            // Null means "use the default" (60/min, 2000/day) -- see the
+            // api-key rate limiter registered in AppServiceProvider.
+            $table->integer('rate_limit_per_minute')->nullable()->after('abilities');
+            $table->integer('rate_limit_per_day')->nullable()->after('rate_limit_per_minute');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->dropColumn(['rate_limit_per_minute', 'rate_limit_per_day']);
+        });
+    }
+};

--- a/database/migrations/2026_08_12_190001_add_user_id_to_short_links_table.php
+++ b/database/migrations/2026_08_12_190001_add_user_id_to_short_links_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('short_links', function (Blueprint $table) {
+            // Null = legacy/admin-created link with no owner -- only an
+            // admin may modify those. Links created through the API are
+            // stamped with the token owner's user id.
+            $table->foreignId('user_id')->nullable()->after('id')
+                ->constrained('users')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('short_links', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('user_id');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "vientiane",
+    "name": "brasilia",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/Pages/Admin/ApiKeys/Index.tsx
+++ b/resources/js/Pages/Admin/ApiKeys/Index.tsx
@@ -1,0 +1,237 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout'
+import { Button } from '@/Components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card'
+import { Input } from '@/Components/ui/input'
+import { Label } from '@/Components/ui/label'
+import { Head, router, useForm, usePage } from '@inertiajs/react'
+import { PageProps as InertiaPageProps } from '@inertiajs/core'
+import { useState } from 'react'
+import { AlertTriangle, Check, Copy, KeyRound, Trash2 } from 'lucide-react'
+
+interface ApiKeyRecord {
+  id: number
+  name: string
+  rate_limit_per_minute: number | null
+  rate_limit_per_day: number | null
+  last_used_at: string | null
+  created_at: string | null
+}
+
+interface Flash {
+  type?: 'success' | 'error'
+  message?: string
+  token?: string
+}
+
+interface PageProps extends InertiaPageProps {
+  flash?: Flash
+}
+
+function formatDate(value: string | null) {
+  if (!value) return 'never'
+  return new Date(value).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      title={copied ? 'Copied' : 'Copy token'}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-amber-900 px-3 py-1.5 text-xs font-medium text-amber-50 transition hover:bg-amber-800"
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  )
+}
+
+interface CreateApiKeyFormData {
+  name: string
+  rate_limit_per_minute: string
+  rate_limit_per_day: string
+  [key: string]: string
+}
+
+export default function Index({ tokens }: { tokens: ApiKeyRecord[] }) {
+  const { flash } = usePage<PageProps>().props
+
+  const { data, setData, post, processing, errors, reset } = useForm<CreateApiKeyFormData>({
+    name: '',
+    rate_limit_per_minute: '',
+    rate_limit_per_day: '',
+  })
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    post(route('admin.api-keys.store'), {
+      preserveScroll: true,
+      onSuccess: () => reset(),
+    })
+  }
+
+  const destroy = (token: ApiKeyRecord) => {
+    if (!confirm(`Revoke "${token.name}"? Anything using this key will stop working immediately.`)) return
+    router.delete(route('admin.api-keys.destroy', token.id), { preserveScroll: true })
+  }
+
+  return (
+    <AuthenticatedLayout
+      header={<h2 className="text-xl font-semibold leading-tight text-gray-800">API Keys</h2>}
+    >
+      <Head title="API Keys" />
+
+      <div className="py-6 sm:py-12">
+        <div className="mx-auto max-w-4xl space-y-6 px-4 sm:px-6 lg:px-8">
+          <p className="text-sm text-gray-500">
+            API keys authenticate requests to the public <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs text-indigo-600">/api/v1</code> endpoints.
+            Each key can carry its own rate limits.
+          </p>
+
+          {flash?.token && (
+            <div className="rounded-lg border border-amber-300 bg-amber-50 p-4">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <p className="text-sm font-semibold text-amber-900">
+                    Copy this key now. You won&apos;t be able to see it again.
+                  </p>
+                  <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-white px-3 py-2">
+                    <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-sm text-gray-800">
+                      {flash.token}
+                    </code>
+                    <CopyButton text={flash.token} />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {!flash?.token && flash?.message && (
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+              {flash.message}
+            </div>
+          )}
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Create API key</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={submit} className="grid gap-4 sm:grid-cols-3">
+                <div className="sm:col-span-1">
+                  <Label htmlFor="name">Name</Label>
+                  <Input
+                    id="name"
+                    className="mt-1"
+                    value={data.name}
+                    onChange={(e) => setData('name', e.target.value)}
+                    placeholder="e.g. Zapier integration"
+                    required
+                  />
+                  {errors.name && <p className="mt-1 text-xs text-red-600">{errors.name}</p>}
+                </div>
+
+                <div className="sm:col-span-1">
+                  <Label htmlFor="rate_limit_per_minute">Rate limit / minute</Label>
+                  <Input
+                    id="rate_limit_per_minute"
+                    type="number"
+                    min={1}
+                    className="mt-1"
+                    value={data.rate_limit_per_minute}
+                    onChange={(e) => setData('rate_limit_per_minute', e.target.value)}
+                    placeholder="default (60)"
+                  />
+                  {errors.rate_limit_per_minute && (
+                    <p className="mt-1 text-xs text-red-600">{errors.rate_limit_per_minute}</p>
+                  )}
+                </div>
+
+                <div className="sm:col-span-1">
+                  <Label htmlFor="rate_limit_per_day">Rate limit / day</Label>
+                  <Input
+                    id="rate_limit_per_day"
+                    type="number"
+                    min={1}
+                    className="mt-1"
+                    value={data.rate_limit_per_day}
+                    onChange={(e) => setData('rate_limit_per_day', e.target.value)}
+                    placeholder="default (2000)"
+                  />
+                  {errors.rate_limit_per_day && (
+                    <p className="mt-1 text-xs text-red-600">{errors.rate_limit_per_day}</p>
+                  )}
+                </div>
+
+                <div className="sm:col-span-3">
+                  <Button type="submit" disabled={processing}>
+                    <KeyRound className="mr-2 h-4 w-4" />
+                    Create API key
+                  </Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            {tokens.length === 0 ? (
+              <div className="px-6 py-16 text-center">
+                <p className="text-sm text-gray-500">No API keys yet.</p>
+              </div>
+            ) : (
+              <table className="min-w-full divide-y divide-gray-100">
+                <thead>
+                  <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-400">
+                    <th className="px-4 py-3">Name</th>
+                    <th className="px-4 py-3">Per minute</th>
+                    <th className="px-4 py-3">Per day</th>
+                    <th className="px-4 py-3">Last used</th>
+                    <th className="px-4 py-3">Created</th>
+                    <th className="px-4 py-3" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {tokens.map((token) => (
+                    <tr key={token.id} className="text-sm text-gray-700">
+                      <td className="px-4 py-3 font-medium text-gray-900">{token.name}</td>
+                      <td className="px-4 py-3 text-gray-500">
+                        {token.rate_limit_per_minute ?? 'default (60/min)'}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500">
+                        {token.rate_limit_per_day ?? 'default (2000/day)'}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500">{formatDate(token.last_used_at)}</td>
+                      <td className="px-4 py-3 text-gray-500">{formatDate(token.created_at)}</td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          onClick={() => destroy(token)}
+                          title="Revoke"
+                          className="rounded-md p-2 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+      </div>
+    </AuthenticatedLayout>
+  )
+}

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -194,6 +194,12 @@ export default function Dashboard({ stats, recentPosts, draftPostsList }: Props)
                             >
                                 Slides & Videos
                             </Link>
+                            <Link
+                                href="/admin/api-keys"
+                                className="inline-flex items-center px-4 py-2 bg-white text-neutral-700 text-sm font-medium rounded-lg border border-neutral-200 hover:bg-neutral-50 transition-colors dark:bg-neutral-800 dark:text-neutral-200 dark:border-neutral-700 dark:hover:bg-neutral-700/50"
+                            >
+                                API Keys
+                            </Link>
                         </div>
                     </div>
                 </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Http\Controllers\Api\QrCodeController;
+use App\Http\Controllers\Api\ShortLinkController;
+use Illuminate\Support\Facades\Route;
+
+// Public API for Harun's other projects: create short links and QR codes
+// with an admin-issued Sanctum token. auth:sanctum rejects unauthenticated
+// requests (401) before throttle:api-key ever runs, so the rate limiter
+// only ever sees a real token.
+Route::middleware(['auth:sanctum', 'throttle:api-key'])
+    ->prefix('v1')
+    ->name('api.v1.')
+    ->group(function () {
+        Route::post('/short-links', [ShortLinkController::class, 'store'])->name('short-links.store');
+        Route::get('/short-links', [ShortLinkController::class, 'index'])->name('short-links.index');
+        Route::get('/short-links/{code}', [ShortLinkController::class, 'show'])->name('short-links.show');
+        Route::patch('/short-links/{code}/deactivate', [ShortLinkController::class, 'deactivate'])->name('short-links.deactivate');
+        Route::delete('/short-links/{code}', [ShortLinkController::class, 'destroy'])->name('short-links.destroy');
+
+        Route::post('/qr-codes', [QrCodeController::class, 'store'])->name('qr-codes.store');
+    });

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\BlogCommentController;
 use App\Http\Controllers\Admin\BioLinkController;
 use App\Http\Controllers\Admin\MediaItemController;
 use App\Http\Controllers\Admin\ShortLinkController;
+use App\Http\Controllers\Admin\ApiKeyController;
 use App\Models\BioLink;
 use App\Models\MediaItem;
 use App\Models\ShortLink;
@@ -122,6 +123,16 @@ Route::middleware(['auth', 'verified', 'role:admin'])
         Route::put('/{shortLink}', [ShortLinkController::class, 'update'])->name('update');
         Route::patch('/{shortLink}/toggle', [ShortLinkController::class, 'toggle'])->name('toggle');
         Route::delete('/{shortLink}', [ShortLinkController::class, 'destroy'])->name('destroy');
+    });
+
+// Admin management of Sanctum API keys used by the public /api/v1 endpoints
+Route::middleware(['auth', 'verified', 'role:admin'])
+    ->prefix('admin/api-keys')
+    ->name('admin.api-keys.')
+    ->group(function () {
+        Route::get('/', [ApiKeyController::class, 'index'])->name('index');
+        Route::post('/', [ApiKeyController::class, 'store'])->name('store');
+        Route::delete('/{id}', [ApiKeyController::class, 'destroy'])->name('destroy');
     });
 
 // Shared by the click-recording routes below: a raw 'src' value (query or

--- a/tests/Feature/Admin/ApiKeyTest.php
+++ b/tests/Feature/Admin/ApiKeyTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\PersonalAccessToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiKeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): User
+    {
+        return User::factory()->create(['email_verified_at' => now(), 'role' => 'admin']);
+    }
+
+    public function test_the_index_requires_authentication(): void
+    {
+        $this->get('/admin/api-keys')->assertRedirect('/login');
+    }
+
+    public function test_a_non_admin_cannot_reach_the_index(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($user)->get('/admin/api-keys')->assertForbidden();
+    }
+
+    public function test_creating_a_key_returns_the_plaintext_token_once_via_flash(): void
+    {
+        $admin = $this->admin();
+
+        $response = $this->actingAs($admin)->post('/admin/api-keys', [
+            'name' => 'My integration',
+            'rate_limit_per_minute' => 30,
+            'rate_limit_per_day' => 500,
+        ]);
+
+        $response->assertRedirect('/admin/api-keys');
+        $response->assertSessionHas('flash.type', 'success');
+        $response->assertSessionHas('flash.token');
+
+        $plaintext = session('flash')['token'];
+        $this->assertIsString($plaintext);
+        $this->assertStringContainsString('|', $plaintext);
+
+        $token = PersonalAccessToken::where('tokenable_id', $admin->id)->first();
+        $this->assertSame('My integration', $token->name);
+        $this->assertSame(30, $token->rate_limit_per_minute);
+        $this->assertSame(500, $token->rate_limit_per_day);
+    }
+
+    public function test_created_keys_default_to_null_rate_limits_when_not_given(): void
+    {
+        $admin = $this->admin();
+
+        $this->actingAs($admin)->post('/admin/api-keys', ['name' => 'No overrides'])
+            ->assertRedirect('/admin/api-keys');
+
+        $token = PersonalAccessToken::first();
+        $this->assertNull($token->rate_limit_per_minute);
+        $this->assertNull($token->rate_limit_per_day);
+    }
+
+    public function test_the_index_lists_the_acting_admins_keys(): void
+    {
+        $admin = $this->admin();
+        $other = $this->admin();
+
+        $admin->createToken('mine', ['*']);
+        $other->createToken('not mine', ['*']);
+
+        // X-Inertia makes this a "subsequent navigation" Inertia request, so
+        // the response is plain page-data JSON rather than the full HTML
+        // shell -- avoids needing a built resources/js/Pages/Admin/ApiKeys
+        // asset, which is out of scope for this backend-only pass. The
+        // version must match what Inertia computes server-side (a hash of
+        // the manifest file), or it 409s asking for a full reload instead.
+        // This also means the usual ->assertInertia() helper doesn't apply
+        // (it expects a rendered Blade view, not a raw JSON response) -- we
+        // assert on $response->json() directly instead, same as
+        // MediaItemTest.
+        $response = $this->actingAs($admin)->get('/admin/api-keys', [
+            'X-Inertia' => 'true',
+            'X-Inertia-Version' => hash_file('xxh128', public_path('build/manifest.json')),
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'component' => 'Admin/ApiKeys/Index',
+        ]);
+        $this->assertCount(1, $response->json('props.tokens'));
+        $this->assertSame('mine', $response->json('props.tokens.0.name'));
+    }
+
+    public function test_an_admin_can_revoke_their_own_key(): void
+    {
+        $admin = $this->admin();
+        $newToken = $admin->createToken('revoke-me', ['*']);
+
+        $this->actingAs($admin)
+            ->delete('/admin/api-keys/'.$newToken->accessToken->id)
+            ->assertRedirect('/admin/api-keys');
+
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $newToken->accessToken->id]);
+    }
+
+    public function test_an_admin_cannot_revoke_another_admins_key(): void
+    {
+        $admin = $this->admin();
+        $other = $this->admin();
+        $newToken = $other->createToken('not-yours', ['*']);
+
+        $this->actingAs($admin)
+            ->delete('/admin/api-keys/'.$newToken->accessToken->id)
+            ->assertNotFound();
+
+        $this->assertDatabaseHas('personal_access_tokens', ['id' => $newToken->accessToken->id]);
+    }
+}

--- a/tests/Feature/AdminPanelTest.php
+++ b/tests/Feature/AdminPanelTest.php
@@ -3,11 +3,14 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class AdminPanelTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function test_admin_panel_redirects_guests(): void
     {
         $this->get(route('admin'))->assertRedirect('/login');

--- a/tests/Feature/Api/QrCodeApiTest.php
+++ b/tests/Feature/Api/QrCodeApiTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class QrCodeApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @return array<string, string> */
+    private function authHeaders(): array
+    {
+        $token = User::factory()->create(['email_verified_at' => now()])->createToken('test-token', ['*']);
+
+        return ['Authorization' => 'Bearer '.$token->plainTextToken];
+    }
+
+    public function test_unauthenticated_requests_are_rejected(): void
+    {
+        $this->postJson('/api/v1/qr-codes', ['content' => 'https://example.com'])->assertUnauthorized();
+    }
+
+    public function test_it_returns_a_valid_data_uri_by_default(): void
+    {
+        $response = $this->postJson('/api/v1/qr-codes', ['content' => 'https://example.com'], $this->authHeaders())
+            ->assertOk()
+            ->assertJsonStructure(['qr_code']);
+
+        $this->assertStringStartsWith('data:image/png;base64,', $response->json('qr_code'));
+
+        [, $base64] = explode(',', $response->json('qr_code'), 2);
+        $bytes = base64_decode($base64, true);
+
+        $this->assertNotFalse($bytes);
+        $this->assertStringStartsWith("\x89PNG", $bytes);
+    }
+
+    public function test_the_png_format_returns_raw_png_bytes(): void
+    {
+        $response = $this->postJson('/api/v1/qr-codes?format=png', ['content' => 'https://example.com'], $this->authHeaders());
+
+        $response->assertOk();
+        $this->assertSame('image/png', $response->headers->get('Content-Type'));
+        $this->assertStringStartsWith("\x89PNG", $response->getContent());
+    }
+
+    public function test_content_is_required(): void
+    {
+        $this->postJson('/api/v1/qr-codes', [], $this->authHeaders())->assertStatus(422);
+    }
+}

--- a/tests/Feature/Api/RateLimitApiTest.php
+++ b/tests/Feature/Api/RateLimitApiTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RateLimitApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_exceeding_the_tokens_per_minute_limit_returns_429_with_headers(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $newToken = $user->createToken('limited', ['*']);
+
+        // A tight per-minute cap so the second request in this test trips it,
+        // without needing to fire 60 real requests.
+        $newToken->accessToken->forceFill(['rate_limit_per_minute' => 1])->save();
+
+        $headers = ['Authorization' => 'Bearer '.$newToken->plainTextToken];
+
+        $this->getJson('/api/v1/short-links', $headers)->assertOk();
+
+        $response = $this->getJson('/api/v1/short-links', $headers);
+
+        $response->assertStatus(429);
+        $this->assertTrue($response->headers->has('X-RateLimit-Limit'));
+        $this->assertTrue($response->headers->has('Retry-After'));
+    }
+
+    public function test_a_token_without_a_configured_limit_falls_back_to_the_default(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $token = $user->createToken('default-limits', ['*']);
+
+        $this->assertNull($token->accessToken->rate_limit_per_minute);
+        $this->assertNull($token->accessToken->rate_limit_per_day);
+
+        $headers = ['Authorization' => 'Bearer '.$token->plainTextToken];
+
+        $this->getJson('/api/v1/short-links', $headers)->assertOk();
+    }
+}

--- a/tests/Feature/Api/ShortLinkApiTest.php
+++ b/tests/Feature/Api/ShortLinkApiTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\ShortLink;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+
+class ShortLinkApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function user(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    private function admin(): User
+    {
+        return User::factory()->create(['email_verified_at' => now(), 'role' => 'admin']);
+    }
+
+    /**
+     * A real Sanctum token (not Sanctum::actingAs's mock) so the api-key
+     * rate limiter -- which reads real columns off the token model on
+     * every /api/v1 request -- has a genuine row to read.
+     *
+     * Sanctum's guard is a RequestGuard, which caches the first user it
+     * resolves for the lifetime of the guard instance. Laravel's test
+     * client reuses that same instance across every call within one test
+     * method, so a second request authenticating as a different user
+     * would otherwise silently resolve back to whoever was cached first.
+     * Forgetting guards here -- right before each header set is built,
+     * i.e. right before the next request goes out -- forces a fresh
+     * resolution per request.
+     *
+     * @return array<string, string>
+     */
+    private function authHeaders(User $user): array
+    {
+        Auth::forgetGuards();
+
+        $token = $user->createToken('test-token', ['*']);
+
+        return ['Authorization' => 'Bearer '.$token->plainTextToken];
+    }
+
+    public function test_unauthenticated_requests_are_rejected(): void
+    {
+        $this->getJson('/api/v1/short-links')->assertUnauthorized();
+        $this->postJson('/api/v1/short-links', ['destination_url' => 'https://example.com'])->assertUnauthorized();
+    }
+
+    public function test_creating_a_short_link_returns_the_expected_shape(): void
+    {
+        $response = $this->postJson('/api/v1/short-links', [
+            'destination_url' => 'https://example.com/target',
+            'title' => 'My link',
+        ], $this->authHeaders($this->user()));
+
+        $response->assertCreated()
+            ->assertJsonStructure(['code', 'short_url', 'destination_url', 'title', 'is_active', 'expires_at', 'qr_code_url'])
+            ->assertJson([
+                'destination_url' => 'https://example.com/target',
+                'title' => 'My link',
+                'is_active' => true,
+                'expires_at' => null,
+            ]);
+    }
+
+    public function test_creating_the_same_url_twice_reuses_the_same_code_and_does_not_duplicate(): void
+    {
+        $headers = $this->authHeaders($this->user());
+
+        $first = $this->postJson('/api/v1/short-links', ['destination_url' => 'https://example.com/dedup'], $headers)
+            ->assertCreated()->json();
+
+        $second = $this->postJson('/api/v1/short-links', ['destination_url' => 'https://example.com/dedup'], $headers)
+            ->assertCreated()->json();
+
+        $this->assertSame($first['code'], $second['code']);
+        $this->assertSame(1, ShortLink::count());
+    }
+
+    public function test_the_token_owner_is_stamped_on_first_creation_only(): void
+    {
+        $owner = $this->user();
+
+        $this->postJson('/api/v1/short-links', ['destination_url' => 'https://example.com/owner-stamp'], $this->authHeaders($owner))
+            ->assertCreated();
+
+        $link = ShortLink::where('destination_url', 'https://example.com/owner-stamp')->first();
+        $this->assertSame($owner->id, $link->user_id);
+
+        $other = $this->user();
+
+        $this->postJson('/api/v1/short-links', ['destination_url' => 'https://example.com/owner-stamp'], $this->authHeaders($other))
+            ->assertCreated();
+
+        $link->refresh();
+        $this->assertSame($owner->id, $link->user_id);
+    }
+
+    public function test_a_non_http_destination_is_rejected(): void
+    {
+        $this->postJson('/api/v1/short-links', ['destination_url' => 'mailto:harun@harun.dev'], $this->authHeaders($this->user()))
+            ->assertStatus(422);
+    }
+
+    public function test_index_lists_only_the_callers_own_links(): void
+    {
+        $owner = $this->user();
+        $stranger = $this->user();
+
+        ShortLink::create(['destination_url' => 'https://example.com/mine', 'user_id' => $owner->id]);
+        ShortLink::create(['destination_url' => 'https://example.com/not-mine', 'user_id' => $stranger->id]);
+
+        $response = $this->getJson('/api/v1/short-links', $this->authHeaders($owner))->assertOk();
+        $urls = collect($response->json('data'))->pluck('destination_url')->all();
+
+        $this->assertContains('https://example.com/mine', $urls);
+        $this->assertNotContains('https://example.com/not-mine', $urls);
+    }
+
+    public function test_index_shows_every_link_for_an_admin_key(): void
+    {
+        $owner = $this->user();
+        $admin = $this->admin();
+
+        ShortLink::create(['destination_url' => 'https://example.com/mine', 'user_id' => $owner->id]);
+        ShortLink::create(['destination_url' => 'https://example.com/legacy']);
+
+        $response = $this->getJson('/api/v1/short-links', $this->authHeaders($admin))->assertOk();
+        $urls = collect($response->json('data'))->pluck('destination_url')->all();
+
+        $this->assertContains('https://example.com/mine', $urls);
+        $this->assertContains('https://example.com/legacy', $urls);
+    }
+
+    public function test_show_includes_click_count(): void
+    {
+        $owner = $this->user();
+        $link = ShortLink::create(['destination_url' => 'https://example.com/clicks', 'user_id' => $owner->id]);
+        $link->clicks()->create(['ip_address' => '127.0.0.1']);
+        $link->clicks()->create(['ip_address' => '127.0.0.2']);
+
+        $this->getJson("/api/v1/short-links/{$link->code}", $this->authHeaders($owner))
+            ->assertOk()
+            ->assertJson(['click_count' => 2]);
+    }
+
+    public function test_show_404s_for_an_unknown_code(): void
+    {
+        $this->getJson('/api/v1/short-links/does-not-exist', $this->authHeaders($this->user()))
+            ->assertNotFound();
+    }
+
+    public function test_owner_can_deactivate_their_own_link(): void
+    {
+        $owner = $this->user();
+        $link = ShortLink::create(['destination_url' => 'https://example.com/deact', 'user_id' => $owner->id]);
+
+        $this->patchJson("/api/v1/short-links/{$link->code}/deactivate", [], $this->authHeaders($owner))
+            ->assertOk()
+            ->assertJson(['is_active' => false]);
+
+        $this->assertFalse($link->fresh()->is_active);
+    }
+
+    public function test_a_non_owner_cannot_deactivate_someone_elses_link(): void
+    {
+        $owner = $this->user();
+        $stranger = $this->user();
+        $link = ShortLink::create(['destination_url' => 'https://example.com/deact2', 'user_id' => $owner->id]);
+
+        $this->patchJson("/api/v1/short-links/{$link->code}/deactivate", [], $this->authHeaders($stranger))
+            ->assertForbidden();
+        $this->assertTrue($link->fresh()->is_active);
+    }
+
+    public function test_an_admin_can_deactivate_any_link(): void
+    {
+        $owner = $this->user();
+        $admin = $this->admin();
+        $link = ShortLink::create(['destination_url' => 'https://example.com/deact3', 'user_id' => $owner->id]);
+
+        $this->patchJson("/api/v1/short-links/{$link->code}/deactivate", [], $this->authHeaders($admin))
+            ->assertOk();
+        $this->assertFalse($link->fresh()->is_active);
+    }
+
+    public function test_a_null_owner_link_is_admin_only(): void
+    {
+        $stranger = $this->user();
+        $admin = $this->admin();
+        $link = ShortLink::create(['destination_url' => 'https://example.com/legacy2']);
+
+        $this->patchJson("/api/v1/short-links/{$link->code}/deactivate", [], $this->authHeaders($stranger))
+            ->assertForbidden();
+
+        $this->patchJson("/api/v1/short-links/{$link->code}/deactivate", [], $this->authHeaders($admin))
+            ->assertOk();
+    }
+
+    public function test_owner_can_delete_their_own_link(): void
+    {
+        $owner = $this->user();
+        $link = ShortLink::create(['destination_url' => 'https://example.com/del', 'user_id' => $owner->id]);
+
+        $this->deleteJson("/api/v1/short-links/{$link->code}", [], $this->authHeaders($owner))
+            ->assertNoContent();
+        $this->assertDatabaseMissing('short_links', ['id' => $link->id]);
+    }
+
+    public function test_a_non_owner_cannot_delete_someone_elses_link(): void
+    {
+        $owner = $this->user();
+        $stranger = $this->user();
+        $link = ShortLink::create(['destination_url' => 'https://example.com/del2', 'user_id' => $owner->id]);
+
+        $this->deleteJson("/api/v1/short-links/{$link->code}", [], $this->authHeaders($stranger))
+            ->assertForbidden();
+        $this->assertDatabaseHas('short_links', ['id' => $link->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a public `/api/v1` API for short-link create/list/read/deactivate/delete and QR code generation
- Secures the API with Laravel Sanctum personal access tokens (API keys) and per-key rate limiting
- Adds an admin panel page (`/admin/api-keys`) to create and revoke keys, showing the plaintext token once on creation
- Uses `endroid/qr-code` for QR generation

## Test plan
- [x] 172 backend tests passing (`php artisan test`)
- [x] Migrations applied to dev DB
- [x] `npm run build` clean
- [x] Manually browser-verified end-to-end admin flow: create key, see token once, revoke

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin API key management, including creation, rate limits, one-time token display, copying, and revocation.
  * Added authenticated v1 APIs for creating, viewing, deactivating, and deleting short links.
  * Added QR code generation with PNG and data-URI responses.
  * Added configurable per-minute and daily API request limits.
  * Added dashboard access to API key management.
* **Bug Fixes**
  * Short links now track ownership and enforce owner/admin permissions.
  * Flash messages are available to application pages.
* **Tests**
  * Added coverage for authentication, authorization, rate limits, short links, QR codes, and API key workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->