### PR TITLE
Redesign admin dashboard with left sidebar nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "brasilia",
+    "name": "dhaka",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -19,6 +19,7 @@
                 "highlight.js": "^11.11.1",
                 "lucide-react": "~1.16.0",
                 "qrcode.react": "^4.2.0",
+                "recharts": "^3.10.1",
                 "sonner": "~2.0.7",
                 "tailwind-merge": "~3.6.0",
                 "tailwindcss-animate": "^1.0.7"
@@ -1066,6 +1067,32 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+            "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
@@ -1328,6 +1355,18 @@
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
             "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
             "license": "MIT"
         },
         "node_modules/@swc/helpers": {
@@ -1678,6 +1717,69 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "license": "MIT"
+        },
         "node_modules/@types/node": {
             "version": "25.9.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
@@ -1707,6 +1809,12 @@
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "6.0.2",
@@ -2118,6 +2226,127 @@
             "devOptional": true,
             "license": "MIT"
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2135,6 +2364,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -2276,13 +2511,14 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.37.2",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.37.2.tgz",
-            "integrity": "sha512-ADDfk+pPFF0ofMpRAIc6on01p8heiuwuuJsYLzTP4UOjxVK9QsE2+0D1Q4J/zX2XBo6ac+27H5++YBIwmGAX/g==",
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
             "license": "MIT",
             "workspaces": [
                 "docs",
-                "benchmarks"
+                "benchmarks",
+                "tests/types"
             ]
         },
         "node_modules/escalade": {
@@ -2294,6 +2530,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
         },
         "node_modules/follow-redirects": {
             "version": "1.16.0",
@@ -2550,6 +2792,25 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/immer": {
+            "version": "11.1.16",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.16.tgz",
+            "integrity": "sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/is-fullwidth-code-point": {
@@ -3108,6 +3369,36 @@
                 "react": "^19.2.6"
             }
         },
+        "node_modules/react-is": {
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+            "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/react-redux": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+            "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-remove-scroll": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
@@ -3195,6 +3486,51 @@
                 }
             }
         },
+        "node_modules/recharts": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+            "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+            "license": "MIT",
+            "workspaces": [
+                "www"
+            ],
+            "dependencies": {
+                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^11.1.8",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.2.0",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
+            }
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3204,6 +3540,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/reselect": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+            "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+            "license": "MIT"
         },
         "node_modules/rolldown": {
             "version": "1.0.2",
@@ -3349,6 +3691,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
+        },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
         },
         "node_modules/tinyglobby": {
             "version": "0.2.16",
@@ -3513,10 +3861,31 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
             "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "license": "MIT AND ISC",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "highlight.js": "^11.11.1",
         "lucide-react": "~1.16.0",
         "qrcode.react": "^4.2.0",
+        "recharts": "^3.10.1",
         "sonner": "~2.0.7",
         "tailwind-merge": "~3.6.0",
         "tailwindcss-animate": "^1.0.7"

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -1,179 +1,222 @@
 import ApplicationLogo from '@/Components/ApplicationLogo';
-import Dropdown from '@/Components/Dropdown';
-import NavLink from '@/Components/NavLink';
-import ResponsiveNavLink from '@/Components/ResponsiveNavLink';
+import {
+    Sheet,
+    SheetContent,
+} from '@/Components/ui/sheet';
 import { Link, usePage } from '@inertiajs/react';
+import {
+    BarChart3,
+    FileText,
+    Image,
+    KeyRound,
+    LayoutDashboard,
+    Link2,
+    LogOut,
+    Menu,
+    User,
+} from 'lucide-react';
 import { PropsWithChildren, ReactNode, useState } from 'react';
+
+interface NavItem {
+    label: string;
+    href: string;
+    icon: typeof LayoutDashboard;
+    active: boolean;
+}
+
+interface NavSection {
+    label: string;
+    items: NavItem[];
+}
+
+function useNavSections(): NavSection[] {
+    return [
+        {
+            label: 'Overview',
+            items: [
+                {
+                    label: 'Dashboard',
+                    href: route('dashboard'),
+                    icon: LayoutDashboard,
+                    active: route().current('dashboard'),
+                },
+            ],
+        },
+        {
+            label: 'Content',
+            items: [
+                {
+                    label: 'Posts',
+                    href: '/admin',
+                    icon: FileText,
+                    active: route().current('admin'),
+                },
+                {
+                    label: 'Bio Links',
+                    href: route('admin.bio.index'),
+                    icon: Link2,
+                    active: route().current('admin.bio.index'),
+                },
+                {
+                    label: 'Bio Analytics',
+                    href: route('admin.bio.analytics'),
+                    icon: BarChart3,
+                    active: route().current('admin.bio.analytics'),
+                },
+                {
+                    label: 'Media',
+                    href: route('admin.media.index'),
+                    icon: Image,
+                    active: route().current('admin.media.index'),
+                },
+                {
+                    label: 'Short Links',
+                    href: route('admin.short.index'),
+                    icon: Link2,
+                    active: route().current('admin.short.index'),
+                },
+                {
+                    label: 'Short Analytics',
+                    href: route('admin.short.analytics'),
+                    icon: BarChart3,
+                    active: route().current('admin.short.analytics'),
+                },
+            ],
+        },
+        {
+            label: 'Account',
+            items: [
+                {
+                    label: 'API Keys',
+                    href: route('admin.api-keys.index'),
+                    icon: KeyRound,
+                    active: route().current('admin.api-keys.index'),
+                },
+                {
+                    label: 'Profile',
+                    href: route('profile.edit'),
+                    icon: User,
+                    active: route().current('profile.edit'),
+                },
+            ],
+        },
+    ];
+}
+
+function NavList({ onNavigate }: { onNavigate?: () => void }) {
+    const sections = useNavSections();
+
+    return (
+        <nav className="flex-1 space-y-6 overflow-y-auto px-3 py-4">
+            {sections.map((section) => (
+                <div key={section.label}>
+                    <p className="px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        {section.label}
+                    </p>
+                    <div className="mt-2 space-y-1">
+                        {section.items.map((item) => {
+                            const Icon = item.icon;
+
+                            return (
+                                <Link
+                                    key={item.label}
+                                    href={item.href}
+                                    onClick={onNavigate}
+                                    className={
+                                        'flex items-center gap-3 rounded-md border-l-2 px-3 py-2 text-sm font-medium transition-colors ' +
+                                        (item.active
+                                            ? 'border-primary bg-primary/10 text-primary'
+                                            : 'border-transparent text-muted-foreground hover:bg-muted hover:text-foreground')
+                                    }
+                                >
+                                    <Icon className="h-4 w-4 shrink-0" />
+                                    {item.label}
+                                </Link>
+                            );
+                        })}
+                    </div>
+                </div>
+            ))}
+        </nav>
+    );
+}
+
+function SidebarUser() {
+    const user = usePage().props.auth.user;
+
+    return (
+        <div className="border-t p-3">
+            <div className="px-3 py-2">
+                <p className="truncate text-sm font-medium text-foreground">
+                    {user.name}
+                </p>
+                <p className="truncate text-xs text-muted-foreground">
+                    {user.email}
+                </p>
+            </div>
+            <Link
+                href={route('logout')}
+                method="post"
+                as="button"
+                className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+                <LogOut className="h-4 w-4 shrink-0" />
+                Log out
+            </Link>
+        </div>
+    );
+}
+
+function SidebarBrand() {
+    return (
+        <Link href="/" className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
+            <ApplicationLogo className="block h-8 w-auto fill-current text-foreground" />
+            <span className="text-sm font-semibold text-foreground">
+                Harun R. Rayhan
+            </span>
+        </Link>
+    );
+}
 
 export default function Authenticated({
     header,
     children,
 }: PropsWithChildren<{ header?: ReactNode }>) {
-    const user = usePage().props.auth.user;
-
-    const [showingNavigationDropdown, setShowingNavigationDropdown] =
-        useState(false);
+    const [showingMobileSidebar, setShowingMobileSidebar] = useState(false);
 
     return (
-        <div className="min-h-screen bg-gray-100">
-            <nav className="border-b border-gray-100 bg-white">
-                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-                    <div className="flex h-16 justify-between">
-                        <div className="flex">
-                            <div className="flex shrink-0 items-center">
-                                <Link href="/">
-                                    <ApplicationLogo className="block h-9 w-auto fill-current text-gray-800" />
-                                </Link>
-                            </div>
+        <div className="flex min-h-screen bg-muted/30">
+            {/* Desktop sidebar */}
+            <aside className="hidden w-64 shrink-0 flex-col border-r bg-background lg:flex">
+                <SidebarBrand />
+                <NavList />
+                <SidebarUser />
+            </aside>
 
-                            <div className="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                                <NavLink
-                                    href={route('dashboard')}
-                                    active={route().current('dashboard')}
-                                >
-                                    Dashboard
-                                </NavLink>
-                            </div>
-                        </div>
+            {/* Mobile sidebar */}
+            <Sheet open={showingMobileSidebar} onOpenChange={setShowingMobileSidebar}>
+                <SheetContent side="left" className="flex w-64 flex-col p-0">
+                    <SidebarBrand />
+                    <NavList onNavigate={() => setShowingMobileSidebar(false)} />
+                    <SidebarUser />
+                </SheetContent>
+            </Sheet>
 
-                        <div className="hidden sm:ms-6 sm:flex sm:items-center">
-                            <div className="relative ms-3">
-                                <Dropdown>
-                                    <Dropdown.Trigger>
-                                        <span className="inline-flex rounded-md">
-                                            <button
-                                                type="button"
-                                                className="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none"
-                                            >
-                                                {user.name}
-
-                                                <svg
-                                                    className="-me-0.5 ms-2 h-4 w-4"
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    viewBox="0 0 20 20"
-                                                    fill="currentColor"
-                                                >
-                                                    <path
-                                                        fillRule="evenodd"
-                                                        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                                        clipRule="evenodd"
-                                                    />
-                                                </svg>
-                                            </button>
-                                        </span>
-                                    </Dropdown.Trigger>
-
-                                    <Dropdown.Content>
-                                        <Dropdown.Link
-                                            href={route('profile.edit')}
-                                        >
-                                            Profile
-                                        </Dropdown.Link>
-                                        <Dropdown.Link
-                                            href={route('logout')}
-                                            method="post"
-                                            as="button"
-                                        >
-                                            Log Out
-                                        </Dropdown.Link>
-                                    </Dropdown.Content>
-                                </Dropdown>
-                            </div>
-                        </div>
-
-                        <div className="-me-2 flex items-center sm:hidden">
-                            <button
-                                onClick={() =>
-                                    setShowingNavigationDropdown(
-                                        (previousState) => !previousState,
-                                    )
-                                }
-                                className="inline-flex items-center justify-center rounded-md p-2 text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none"
-                            >
-                                <svg
-                                    className="h-6 w-6"
-                                    stroke="currentColor"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                >
-                                    <path
-                                        className={
-                                            !showingNavigationDropdown
-                                                ? 'inline-flex'
-                                                : 'hidden'
-                                        }
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth="2"
-                                        d="M4 6h16M4 12h16M4 18h16"
-                                    />
-                                    <path
-                                        className={
-                                            showingNavigationDropdown
-                                                ? 'inline-flex'
-                                                : 'hidden'
-                                        }
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth="2"
-                                        d="M6 18L18 6M6 6l12 12"
-                                    />
-                                </svg>
-                            </button>
-                        </div>
-                    </div>
+            {/* Main column */}
+            <div className="flex min-w-0 flex-1 flex-col">
+                <div className="sticky top-0 z-30 flex h-14 items-center gap-3 border-b bg-background px-4">
+                    <button
+                        type="button"
+                        onClick={() => setShowingMobileSidebar(true)}
+                        className="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:hidden"
+                    >
+                        <Menu className="h-5 w-5" />
+                    </button>
+                    <div className="min-w-0 flex-1">{header}</div>
                 </div>
 
-                <div
-                    className={
-                        (showingNavigationDropdown ? 'block' : 'hidden') +
-                        ' sm:hidden'
-                    }
-                >
-                    <div className="space-y-1 pb-3 pt-2">
-                        <ResponsiveNavLink
-                            href={route('dashboard')}
-                            active={route().current('dashboard')}
-                        >
-                            Dashboard
-                        </ResponsiveNavLink>
-                    </div>
-
-                    <div className="border-t border-gray-200 pb-1 pt-4">
-                        <div className="px-4">
-                            <div className="text-base font-medium text-gray-800">
-                                {user.name}
-                            </div>
-                            <div className="text-sm font-medium text-gray-500">
-                                {user.email}
-                            </div>
-                        </div>
-
-                        <div className="mt-3 space-y-1">
-                            <ResponsiveNavLink href={route('profile.edit')}>
-                                Profile
-                            </ResponsiveNavLink>
-                            <ResponsiveNavLink
-                                method="post"
-                                href={route('logout')}
-                                as="button"
-                            >
-                                Log Out
-                            </ResponsiveNavLink>
-                        </div>
-                    </div>
-                </div>
-            </nav>
-
-            {header && (
-                <header className="bg-white shadow">
-                    <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-                        {header}
-                    </div>
-                </header>
-            )}
-
-            <main>{children}</main>
+                <main className="flex-1">{children}</main>
+            </div>
         </div>
     );
 }

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -1,6 +1,24 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import { Head, Link } from '@inertiajs/react';
 import { getImageUrl } from "@/lib/imageUtils";
+import {
+    Area,
+    AreaChart,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts';
+import {
+    CheckCircle2,
+    Eye,
+    FileText,
+    Image as ImageIcon,
+    KeyRound,
+    Link2,
+    PenLine,
+} from 'lucide-react';
 
 interface PostSummary {
     title: string;
@@ -21,15 +39,55 @@ interface DashboardStats {
     previewReadyDrafts: number;
 }
 
+interface PostsTrendPoint {
+    label: string;
+    count: number;
+}
+
 interface Props {
     stats: DashboardStats;
     panelStatus: string;
     panelStatusDetail: string;
     recentPosts: PostSummary[];
     draftPostsList: PostSummary[];
+    postsTrend: PostsTrendPoint[];
 }
 
-export default function Dashboard({ stats, recentPosts, draftPostsList }: Props) {
+const statCards = (stats: DashboardStats) => [
+    {
+        label: 'Total Posts',
+        value: stats.totalPosts,
+        icon: FileText,
+        badgeClassName: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
+    },
+    {
+        label: 'Published',
+        value: stats.publishedPosts,
+        icon: CheckCircle2,
+        badgeClassName: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400',
+    },
+    {
+        label: 'Drafts',
+        value: stats.draftPosts,
+        icon: PenLine,
+        badgeClassName: 'bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400',
+    },
+    {
+        label: 'Preview Ready',
+        value: stats.previewReadyDrafts,
+        icon: Eye,
+        badgeClassName: 'bg-blue-100 text-blue-600 dark:bg-blue-950 dark:text-blue-400',
+    },
+];
+
+const quickActions = [
+    { label: 'View All Posts', href: '/admin', icon: FileText },
+    { label: 'Short Links', href: '/admin/short', icon: Link2 },
+    { label: 'Slides & Videos', href: '/admin/media', icon: ImageIcon },
+    { label: 'API Keys', href: '/admin/api-keys', icon: KeyRound },
+];
+
+export default function Dashboard({ stats, recentPosts, draftPostsList, postsTrend }: Props) {
     return (
         <AuthenticatedLayout
             header={
@@ -80,63 +138,111 @@ export default function Dashboard({ stats, recentPosts, draftPostsList }: Props)
 
             <div className="py-6 sm:py-12">
                 <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-6">
+                    {/* Posts Published trend */}
+                    <Card>
+                        <CardHeader>
+                            <CardTitle className="text-base font-semibold">Posts Published</CardTitle>
+                            <p className="text-sm text-muted-foreground">Published posts per month, last 6 months</p>
+                        </CardHeader>
+                        <CardContent className="h-64 pl-0">
+                            <ResponsiveContainer width="100%" height="100%">
+                                <AreaChart data={postsTrend} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                                    <defs>
+                                        <linearGradient id="postsTrendFill" x1="0" y1="0" x2="0" y2="1">
+                                            <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.35} />
+                                            <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0} />
+                                        </linearGradient>
+                                    </defs>
+                                    <XAxis
+                                        dataKey="label"
+                                        axisLine={false}
+                                        tickLine={false}
+                                        tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
+                                    />
+                                    <YAxis
+                                        allowDecimals={false}
+                                        axisLine={false}
+                                        tickLine={false}
+                                        width={28}
+                                        tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
+                                    />
+                                    <Tooltip
+                                        contentStyle={{
+                                            backgroundColor: 'hsl(var(--card))',
+                                            borderColor: 'hsl(var(--border))',
+                                            borderRadius: 8,
+                                            fontSize: 12,
+                                        }}
+                                        labelStyle={{ color: 'hsl(var(--foreground))' }}
+                                    />
+                                    <Area
+                                        type="monotone"
+                                        dataKey="count"
+                                        stroke="hsl(var(--primary))"
+                                        strokeWidth={2}
+                                        fill="url(#postsTrendFill)"
+                                    />
+                                </AreaChart>
+                            </ResponsiveContainer>
+                        </CardContent>
+                    </Card>
+
                     {/* Stats Cards */}
                     <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                        <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
-                            <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Total Posts</p>
-                            <p className="text-2xl sm:text-3xl font-semibold text-neutral-900 dark:text-white mt-1">{stats.totalPosts}</p>
-                        </div>
-                        <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
-                            <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Published</p>
-                            <p className="text-2xl sm:text-3xl font-semibold text-emerald-600 dark:text-emerald-400 mt-1">{stats.publishedPosts}</p>
-                        </div>
-                        <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
-                            <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Drafts</p>
-                            <p className="text-2xl sm:text-3xl font-semibold text-amber-600 dark:text-amber-400 mt-1">{stats.draftPosts}</p>
-                        </div>
-                        <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg p-4 sm:p-6 border border-neutral-200 dark:border-neutral-700">
-                            <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">Preview Ready</p>
-                            <p className="text-2xl sm:text-3xl font-semibold text-blue-600 dark:text-blue-400 mt-1">{stats.previewReadyDrafts}</p>
-                        </div>
+                        {statCards(stats).map((stat) => {
+                            const Icon = stat.icon;
+
+                            return (
+                                <Card key={stat.label}>
+                                    <CardContent className="p-4 sm:p-6">
+                                        <div className={`inline-flex h-9 w-9 items-center justify-center rounded-lg ${stat.badgeClassName}`}>
+                                            <Icon className="h-5 w-5" />
+                                        </div>
+                                        <p className="text-2xl sm:text-3xl font-semibold text-foreground mt-3">{stat.value}</p>
+                                        <p className="text-sm font-medium text-muted-foreground">{stat.label}</p>
+                                    </CardContent>
+                                </Card>
+                            );
+                        })}
                     </div>
 
                     {/* Recent Published Posts */}
-                    <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg border border-neutral-200 dark:border-neutral-700">
-                        <div className="px-4 sm:px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
-                            <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Recent Published Posts</h3>
-                        </div>
-                        <div className="divide-y divide-neutral-200 dark:divide-neutral-700">
+                    <Card>
+                        <CardHeader className="border-b">
+                            <CardTitle className="text-lg font-semibold">Recent Published Posts</CardTitle>
+                        </CardHeader>
+                        <CardContent className="p-0 divide-y">
                             {recentPosts.length > 0 ? recentPosts.map((post) => (
                                 <Link
                                     key={post.slug}
                                     href={post.url}
-                                    className="block px-4 sm:px-6 py-4 hover:bg-neutral-50 dark:hover:bg-neutral-700/50 transition-colors"
+                                    className="block px-4 sm:px-6 py-4 hover:bg-muted/50 transition-colors"
                                 >
                                     <div className="flex items-start justify-between gap-4">
                                         <div className="min-w-0 flex-1">
-                                            <p className="text-sm font-medium text-neutral-900 dark:text-white truncate">{post.title}</p>
-                                            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5 line-clamp-1">{post.brief}</p>
+                                            <p className="text-sm font-medium text-foreground truncate">{post.title}</p>
+                                            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{post.brief}</p>
                                         </div>
                                         <div className="flex items-center gap-3 shrink-0">
-                                            <span className="text-xs text-neutral-400 dark:text-neutral-500">{post.publishedAtHuman}</span>
-                                            <span className="text-xs text-neutral-400 dark:text-neutral-500">{post.readTimeLabel}</span>
+                                            <span className="text-xs text-muted-foreground">{post.publishedAtHuman}</span>
+                                            <span className="text-xs text-muted-foreground">{post.readTimeLabel}</span>
                                         </div>
                                     </div>
                                 </Link>
                             )) : (
-                                <div className="px-4 sm:px-6 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                                <div className="px-4 sm:px-6 py-8 text-center text-sm text-muted-foreground">
                                     No published posts yet.
                                 </div>
                             )}
-                        </div>
-                    </div>
+                        </CardContent>
+                    </Card>
 
                     {/* Draft Posts */}
-                    <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg border border-neutral-200 dark:border-neutral-700">
-                        <div className="px-4 sm:px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
-                            <h3 className="text-lg font-semibold text-amber-600 dark:text-amber-400">Draft Posts</h3>
-                        </div>
-                        <div className="divide-y divide-neutral-200 dark:divide-neutral-700">
+                    <Card>
+                        <CardHeader className="border-b">
+                            <CardTitle className="text-lg font-semibold text-amber-600 dark:text-amber-400">Draft Posts</CardTitle>
+                        </CardHeader>
+                        <CardContent className="p-0 divide-y">
                             {draftPostsList.length > 0 ? draftPostsList.map((post) => (
                                 <div
                                     key={post.slug}
@@ -144,8 +250,8 @@ export default function Dashboard({ stats, recentPosts, draftPostsList }: Props)
                                 >
                                     <div className="flex items-start justify-between gap-4">
                                         <div className="min-w-0 flex-1">
-                                            <p className="text-sm font-medium text-neutral-900 dark:text-white">{post.title}</p>
-                                            <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5 line-clamp-1">{post.brief}</p>
+                                            <p className="text-sm font-medium text-foreground">{post.title}</p>
+                                            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{post.brief}</p>
                                             <div className="flex items-center gap-3 mt-1.5">
                                                 <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">{post.readTimeLabel}</span>
                                                 {post.draftPreviewUrl && (
@@ -163,45 +269,38 @@ export default function Dashboard({ stats, recentPosts, draftPostsList }: Props)
                                     </div>
                                 </div>
                             )) : (
-                                <div className="px-4 sm:px-6 py-8 text-center text-sm text-neutral-500 dark:text-neutral-400">
+                                <div className="px-4 sm:px-6 py-8 text-center text-sm text-muted-foreground">
                                     No draft posts.
                                 </div>
                             )}
-                        </div>
-                    </div>
+                        </CardContent>
+                    </Card>
 
                     {/* Quick Actions */}
-                    <div className="bg-white dark:bg-neutral-800 shadow-sm rounded-lg border border-neutral-200 dark:border-neutral-700">
-                        <div className="px-4 sm:px-6 py-4 border-b border-neutral-200 dark:border-neutral-700">
-                            <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Quick Actions</h3>
-                        </div>
-                        <div className="px-4 sm:px-6 py-4 flex flex-wrap gap-3">
-                            <Link
-                                href="/admin"
-                                className="inline-flex items-center px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
-                            >
-                                View All Posts
-                            </Link>
-                            <Link
-                                href="/admin/short"
-                                className="inline-flex items-center px-4 py-2 bg-white text-neutral-700 text-sm font-medium rounded-lg border border-neutral-200 hover:bg-neutral-50 transition-colors dark:bg-neutral-800 dark:text-neutral-200 dark:border-neutral-700 dark:hover:bg-neutral-700/50"
-                            >
-                                Short Links
-                            </Link>
-                            <Link
-                                href="/admin/media"
-                                className="inline-flex items-center px-4 py-2 bg-white text-neutral-700 text-sm font-medium rounded-lg border border-neutral-200 hover:bg-neutral-50 transition-colors dark:bg-neutral-800 dark:text-neutral-200 dark:border-neutral-700 dark:hover:bg-neutral-700/50"
-                            >
-                                Slides & Videos
-                            </Link>
-                            <Link
-                                href="/admin/api-keys"
-                                className="inline-flex items-center px-4 py-2 bg-white text-neutral-700 text-sm font-medium rounded-lg border border-neutral-200 hover:bg-neutral-50 transition-colors dark:bg-neutral-800 dark:text-neutral-200 dark:border-neutral-700 dark:hover:bg-neutral-700/50"
-                            >
-                                API Keys
-                            </Link>
-                        </div>
-                    </div>
+                    <Card>
+                        <CardHeader className="border-b">
+                            <CardTitle className="text-lg font-semibold">Manage</CardTitle>
+                            <p className="text-sm text-muted-foreground">Quick shortcuts to the rest of the admin area</p>
+                        </CardHeader>
+                        <CardContent className="grid grid-cols-2 sm:grid-cols-4 gap-3 p-4 sm:p-6">
+                            {quickActions.map((action) => {
+                                const Icon = action.icon;
+
+                                return (
+                                    <Link
+                                        key={action.label}
+                                        href={action.href}
+                                        className="flex flex-col items-center gap-2 rounded-lg border bg-card px-4 py-5 text-center transition-colors hover:bg-muted/50"
+                                    >
+                                        <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                                            <Icon className="h-5 w-5" />
+                                        </span>
+                                        <span className="text-sm font-medium text-foreground">{action.label}</span>
+                                    </Link>
+                                );
+                            })}
+                        </CardContent>
+                    </Card>
                 </div>
             </div>
         </AuthenticatedLayout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,21 @@ $renderDashboard = function () {
     $publishedPosts = array_values(array_filter($posts, fn (array $post) => ! (bool) ($post['draft'] ?? false)));
     $draftPosts = array_values(array_filter($posts, fn (array $post) => (bool) ($post['draft'] ?? false)));
 
+    $postsByMonth = [];
+    foreach ($publishedPosts as $post) {
+        $month = Carbon::parse($post['publishedAt'])->format('Y-m');
+        $postsByMonth[$month] = ($postsByMonth[$month] ?? 0) + 1;
+    }
+
+    $postsTrend = [];
+    for ($i = 5; $i >= 0; $i--) {
+        $month = Carbon::now()->subMonths($i);
+        $postsTrend[] = [
+            'label' => $month->format('M'),
+            'count' => $postsByMonth[$month->format('Y-m')] ?? 0,
+        ];
+    }
+
     return Inertia::render('Dashboard', [
         'stats' => [
             'totalPosts' => count($posts),
@@ -68,6 +83,7 @@ $renderDashboard = function () {
             'readTimeLabel' => (string) ($post['readTimeLabel'] ?? ''),
             'draftPreviewUrl' => $blog->previewUrl((string) $post['slug']),
         ], $draftPosts),
+        'postsTrend' => $postsTrend,
     ]);
 };
 


### PR DESCRIPTION
## Summary
- Replace the shared top-nav `AuthenticatedLayout` with a left sidebar (desktop fixed, mobile `Sheet` drawer) across all admin/authenticated pages
- Rebuild the `/dashboard` body: icon stat cards + a recharts area chart of posts-published per month (last 6 months)

## Test plan
- [x] `npm run build` compiles cleanly
- [x] Verified in a real browser (desktop 1440x900 + mobile 390x844) against a local seeded DB
- [x] Sidebar renders on `/dashboard`, `/admin/bio`, `/admin/bio/analytics` with correct active-nav highlighting
- [x] Mobile hamburger opens the Sheet drawer with the same nav links, and it closes on navigation
- [x] Back-link header (`Admin/Bio/Analytics.tsx`) still renders inside the slim top bar
- [x] Dark-mode tokens verified by forcing the `.dark` class (app has no live toggle) — sidebar/cards/chart render correctly

Generated with [Claude Code](https://claude.ai/code)