### PR TITLE
Remove public menu bar from admin area

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -17,8 +17,12 @@ createInertiaApp({
     resolve: async (name) => {
         const page = (await pages[`./Pages/${name}.tsx`]()).default;
 
-        // Apply PublicLayout as default for all pages unless they specify their own
-        if (!page.layout) {
+        // Admin/authenticated pages render their own AuthenticatedLayout (sidebar nav)
+        // and don't need the public marketing Menubar/Footer.
+        const isAdminArea = name === 'Dashboard' || name === 'Profile/Edit' || name.startsWith('Admin/');
+
+        // Apply PublicLayout as default for all other pages unless they specify their own
+        if (!page.layout && !isAdminArea) {
             page.layout = PublicLayout
         }
 


### PR DESCRIPTION
## Summary
- Admin/authenticated pages (`Dashboard`, `Profile/Edit`, `Admin/*`) no longer get wrapped in the public `PublicLayout` (marketing top Menubar + footer) — they already have their own sidebar nav from `AuthenticatedLayout`
- Public pages are unaffected

## Test plan
- [x] Verified in browser: `/dashboard`, `/admin/bio/analytics` have no marketing header/footer, sidebar and "Back to links" header still work
- [x] Verified `/` (public) still renders the marketing Menubar + footer
- [x] `tsc --noEmit` passes

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dashboard, profile editing, and administration pages to control their own layouts.
  * Preserved the existing default layout behavior for other pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->