### PR TITLE
Make admin sidebar sticky

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -187,7 +187,7 @@ export default function Authenticated({
     return (
         <div className="flex min-h-screen bg-muted/30">
             {/* Desktop sidebar */}
-            <aside className="hidden w-64 shrink-0 flex-col border-r bg-background lg:flex">
+            <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col border-r bg-background lg:flex">
                 <SidebarBrand />
                 <NavList />
                 <SidebarUser />


### PR DESCRIPTION
## Summary
- Desktop admin sidebar is now `sticky top-0 h-screen` instead of scrolling away with page content — it stays pinned to the left while the main column scrolls

## Test plan
- [x] Verified in browser: scrolled `/dashboard` 800px, sidebar bounding box stayed pinned at viewport top/bottom (`position: sticky`)
- [x] Mobile unaffected — `<aside>` still `display: none` below `lg`, Sheet drawer unchanged

Generated with [Claude Code](https://claude.ai/code)