### PR TITLE
Revamp admin dashboard UI, move it to /admin/dashboard

### DIFF
--- a/resources/js/Components/Menubar.tsx
+++ b/resources/js/Components/Menubar.tsx
@@ -224,7 +224,7 @@ export function Menubar() {
               {profileOpen && (
                 <div className="absolute right-0 top-full z-50 mt-2 w-48 origin-top-right rounded-xl border border-slate-200 bg-white p-1.5 shadow-lg">
                   <Link
-                    href="/dashboard"
+                    href={route('dashboard')}
                     className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100"
                     onClick={() => setProfileOpen(false)}
                   >
@@ -328,7 +328,7 @@ export function Menubar() {
                     </div>
                     <SheetClose asChild>
                       <Link
-                        href="/dashboard"
+                        href={route('dashboard')}
                         className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-4 py-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
                       >
                         <User className="h-4 w-4" />

--- a/resources/js/Components/SubscribeProvider.tsx
+++ b/resources/js/Components/SubscribeProvider.tsx
@@ -10,7 +10,7 @@ const DISMISS_KEY = 'subscribe-popup-dismissed'
 
 /** Admin/authenticated pages (sidebar layout) never show the subscribe popup. */
 function isAdminPath(pathname: string) {
-  return pathname === '/dashboard' || pathname === '/profile' || pathname.startsWith('/admin')
+  return pathname === '/profile' || pathname.startsWith('/admin')
 }
 
 function useIsAdminArea() {

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -169,7 +169,7 @@ function SidebarUser() {
 
 function SidebarBrand() {
     return (
-        <Link href="/" className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
+        <Link href="/" target="_blank" rel="noopener noreferrer" className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
             <ApplicationLogo className="block h-8 w-auto fill-current text-foreground" />
             <span className="text-sm font-semibold text-foreground">
                 Harun R. Rayhan

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -6,7 +6,6 @@ import {
 import { Link, usePage } from '@inertiajs/react';
 import {
     BarChart3,
-    FileText,
     Image,
     KeyRound,
     LayoutDashboard,
@@ -45,12 +44,6 @@ function useNavSections(): NavSection[] {
         {
             label: 'Content',
             items: [
-                {
-                    label: 'Posts',
-                    href: '/admin',
-                    icon: FileText,
-                    active: route().current('admin'),
-                },
                 {
                     label: 'Bio Links',
                     href: route('admin.bio.index'),
@@ -169,12 +162,12 @@ function SidebarUser() {
 
 function SidebarBrand() {
     return (
-        <Link href="/" target="_blank" rel="noopener noreferrer" className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
+        <a href="/" target="_blank" rel="noopener noreferrer" className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
             <ApplicationLogo className="block h-8 w-auto fill-current text-foreground" />
             <span className="text-sm font-semibold text-foreground">
                 Harun R. Rayhan
             </span>
-        </Link>
+        </a>
     );
 }
 

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -1,23 +1,31 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Components/ui/card';
 import { Head, Link } from '@inertiajs/react';
 import { getImageUrl } from "@/lib/imageUtils";
 import {
     Area,
     AreaChart,
+    CartesianGrid,
     ResponsiveContainer,
     Tooltip,
     XAxis,
     YAxis,
 } from 'recharts';
 import {
+    ArrowUpRight,
+    CalendarDays,
     CheckCircle2,
+    ChevronRight,
+    Clock,
+    ExternalLink,
     Eye,
     FileText,
     Image as ImageIcon,
+    Inbox,
     KeyRound,
     Link2,
     PenLine,
+    TrendingUp,
 } from 'lucide-react';
 
 interface PostSummary {
@@ -58,25 +66,29 @@ const statCards = (stats: DashboardStats) => [
         label: 'Total Posts',
         value: stats.totalPosts,
         icon: FileText,
-        badgeClassName: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
+        iconClassName: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
+        accentClassName: 'bg-slate-300 dark:bg-slate-600',
     },
     {
         label: 'Published',
         value: stats.publishedPosts,
         icon: CheckCircle2,
-        badgeClassName: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400',
+        iconClassName: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400',
+        accentClassName: 'bg-emerald-500',
     },
     {
         label: 'Drafts',
         value: stats.draftPosts,
         icon: PenLine,
-        badgeClassName: 'bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400',
+        iconClassName: 'bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400',
+        accentClassName: 'bg-amber-500',
     },
     {
         label: 'Preview Ready',
         value: stats.previewReadyDrafts,
         icon: Eye,
-        badgeClassName: 'bg-blue-100 text-blue-600 dark:bg-blue-950 dark:text-blue-400',
+        iconClassName: 'bg-blue-100 text-blue-600 dark:bg-blue-950 dark:text-blue-400',
+        accentClassName: 'bg-blue-500',
     },
 ];
 
@@ -87,13 +99,43 @@ const quickActions = [
     { label: 'API Keys', href: '/admin/api-keys', icon: KeyRound },
 ];
 
-export default function Dashboard({ stats, recentPosts, draftPostsList, postsTrend }: Props) {
+function CountBadge({ value }: { value: number }) {
+    return (
+        <span className="inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full bg-muted px-2 text-xs font-medium tabular-nums text-muted-foreground">
+            {value}
+        </span>
+    );
+}
+
+function EmptyState({ icon: Icon, message }: { icon: typeof Inbox; message: string }) {
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                <Icon className="h-5 w-5" />
+            </span>
+            <p className="text-sm text-muted-foreground">{message}</p>
+        </div>
+    );
+}
+
+export default function Dashboard({ stats, panelStatus, panelStatusDetail, recentPosts, draftPostsList, postsTrend }: Props) {
+    const trendTotal = postsTrend.reduce((sum, point) => sum + point.count, 0);
+
     return (
         <AuthenticatedLayout
             header={
-                <h2 className="text-xl font-semibold leading-tight text-gray-800 dark:text-neutral-100">
-                    Dashboard
-                </h2>
+                <div className="flex items-center gap-3">
+                    <h2 className="text-xl font-semibold leading-tight text-foreground">
+                        Dashboard
+                    </h2>
+                    <span
+                        title={panelStatusDetail}
+                        className="hidden items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 sm:inline-flex dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-400"
+                    >
+                        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                        {panelStatus}
+                    </span>
+                </div>
             }
         >
             <Head>
@@ -136,27 +178,66 @@ export default function Dashboard({ stats, recentPosts, draftPostsList, postsTre
                 </script>
             </Head>
 
-            <div className="py-6 sm:py-12">
-                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-6">
+            <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+                {/* Stats Cards */}
+                <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                    {statCards(stats).map((stat) => {
+                        const Icon = stat.icon;
+
+                        return (
+                            <Card key={stat.label} className="relative overflow-hidden transition-shadow hover:shadow-md">
+                                <span className={`absolute inset-x-0 top-0 h-0.5 ${stat.accentClassName}`} aria-hidden="true" />
+                                <CardContent className="flex items-start justify-between gap-3 p-4 pt-4 sm:p-5 sm:pt-5">
+                                    <div className="min-w-0">
+                                        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                            {stat.label}
+                                        </p>
+                                        <p className="mt-2 text-2xl font-semibold tabular-nums leading-none text-foreground sm:text-3xl">
+                                            {stat.value}
+                                        </p>
+                                    </div>
+                                    <span className={`inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${stat.iconClassName}`}>
+                                        <Icon className="h-[18px] w-[18px]" />
+                                    </span>
+                                </CardContent>
+                            </Card>
+                        );
+                    })}
+                </div>
+
+                <div className="grid gap-6 lg:grid-cols-3">
                     {/* Posts Published trend */}
-                    <Card>
-                        <CardHeader>
-                            <CardTitle className="text-base font-semibold">Posts Published</CardTitle>
-                            <p className="text-sm text-muted-foreground">Published posts per month, last 6 months</p>
+                    <Card className="lg:col-span-2">
+                        <CardHeader className="flex-row items-start justify-between gap-4 space-y-0 border-b p-5">
+                            <div className="space-y-1">
+                                <CardTitle className="text-base font-semibold">Posts Published</CardTitle>
+                                <CardDescription>Published posts per month, last 6 months</CardDescription>
+                            </div>
+                            <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                                <TrendingUp className="h-3.5 w-3.5" />
+                                <span className="tabular-nums">{trendTotal}</span>
+                                in 6 mo
+                            </span>
                         </CardHeader>
-                        <CardContent className="h-64 pl-0">
+                        <CardContent className="h-64 p-5 pl-1">
                             <ResponsiveContainer width="100%" height="100%">
-                                <AreaChart data={postsTrend} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                                <AreaChart data={postsTrend} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
                                     <defs>
                                         <linearGradient id="postsTrendFill" x1="0" y1="0" x2="0" y2="1">
-                                            <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.35} />
+                                            <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.3} />
                                             <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0} />
                                         </linearGradient>
                                     </defs>
+                                    <CartesianGrid
+                                        vertical={false}
+                                        strokeDasharray="3 3"
+                                        stroke="hsl(var(--border))"
+                                    />
                                     <XAxis
                                         dataKey="label"
                                         axisLine={false}
                                         tickLine={false}
+                                        tickMargin={8}
                                         tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
                                     />
                                     <YAxis
@@ -167,11 +248,13 @@ export default function Dashboard({ stats, recentPosts, draftPostsList, postsTre
                                         tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
                                     />
                                     <Tooltip
+                                        cursor={{ stroke: 'hsl(var(--border))', strokeWidth: 1 }}
                                         contentStyle={{
                                             backgroundColor: 'hsl(var(--card))',
                                             borderColor: 'hsl(var(--border))',
                                             borderRadius: 8,
                                             fontSize: 12,
+                                            boxShadow: '0 4px 12px rgb(0 0 0 / 0.08)',
                                         }}
                                         labelStyle={{ color: 'hsl(var(--foreground))' }}
                                     />
@@ -181,108 +264,20 @@ export default function Dashboard({ stats, recentPosts, draftPostsList, postsTre
                                         stroke="hsl(var(--primary))"
                                         strokeWidth={2}
                                         fill="url(#postsTrendFill)"
+                                        activeDot={{ r: 4, strokeWidth: 2, stroke: 'hsl(var(--card))' }}
                                     />
                                 </AreaChart>
                             </ResponsiveContainer>
                         </CardContent>
                     </Card>
 
-                    {/* Stats Cards */}
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                        {statCards(stats).map((stat) => {
-                            const Icon = stat.icon;
-
-                            return (
-                                <Card key={stat.label}>
-                                    <CardContent className="p-4 sm:p-6">
-                                        <div className={`inline-flex h-9 w-9 items-center justify-center rounded-lg ${stat.badgeClassName}`}>
-                                            <Icon className="h-5 w-5" />
-                                        </div>
-                                        <p className="text-2xl sm:text-3xl font-semibold text-foreground mt-3">{stat.value}</p>
-                                        <p className="text-sm font-medium text-muted-foreground">{stat.label}</p>
-                                    </CardContent>
-                                </Card>
-                            );
-                        })}
-                    </div>
-
-                    {/* Recent Published Posts */}
-                    <Card>
-                        <CardHeader className="border-b">
-                            <CardTitle className="text-lg font-semibold">Recent Published Posts</CardTitle>
-                        </CardHeader>
-                        <CardContent className="p-0 divide-y">
-                            {recentPosts.length > 0 ? recentPosts.map((post) => (
-                                <Link
-                                    key={post.slug}
-                                    href={post.url}
-                                    className="block px-4 sm:px-6 py-4 hover:bg-muted/50 transition-colors"
-                                >
-                                    <div className="flex items-start justify-between gap-4">
-                                        <div className="min-w-0 flex-1">
-                                            <p className="text-sm font-medium text-foreground truncate">{post.title}</p>
-                                            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{post.brief}</p>
-                                        </div>
-                                        <div className="flex items-center gap-3 shrink-0">
-                                            <span className="text-xs text-muted-foreground">{post.publishedAtHuman}</span>
-                                            <span className="text-xs text-muted-foreground">{post.readTimeLabel}</span>
-                                        </div>
-                                    </div>
-                                </Link>
-                            )) : (
-                                <div className="px-4 sm:px-6 py-8 text-center text-sm text-muted-foreground">
-                                    No published posts yet.
-                                </div>
-                            )}
-                        </CardContent>
-                    </Card>
-
-                    {/* Draft Posts */}
-                    <Card>
-                        <CardHeader className="border-b">
-                            <CardTitle className="text-lg font-semibold text-amber-600 dark:text-amber-400">Draft Posts</CardTitle>
-                        </CardHeader>
-                        <CardContent className="p-0 divide-y">
-                            {draftPostsList.length > 0 ? draftPostsList.map((post) => (
-                                <div
-                                    key={post.slug}
-                                    className="px-4 sm:px-6 py-4"
-                                >
-                                    <div className="flex items-start justify-between gap-4">
-                                        <div className="min-w-0 flex-1">
-                                            <p className="text-sm font-medium text-foreground">{post.title}</p>
-                                            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{post.brief}</p>
-                                            <div className="flex items-center gap-3 mt-1.5">
-                                                <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">{post.readTimeLabel}</span>
-                                                {post.draftPreviewUrl && (
-                                                    <a
-                                                        href={post.draftPreviewUrl}
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-                                                    >
-                                                        Preview
-                                                    </a>
-                                                )}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            )) : (
-                                <div className="px-4 sm:px-6 py-8 text-center text-sm text-muted-foreground">
-                                    No draft posts.
-                                </div>
-                            )}
-                        </CardContent>
-                    </Card>
-
                     {/* Quick Actions */}
                     <Card>
-                        <CardHeader className="border-b">
-                            <CardTitle className="text-lg font-semibold">Manage</CardTitle>
-                            <p className="text-sm text-muted-foreground">Quick shortcuts to the rest of the admin area</p>
+                        <CardHeader className="space-y-1 border-b p-5">
+                            <CardTitle className="text-base font-semibold">Manage</CardTitle>
+                            <CardDescription>Quick shortcuts to the rest of the admin area</CardDescription>
                         </CardHeader>
-                        <CardContent className="grid grid-cols-2 sm:grid-cols-4 gap-3 p-4 sm:p-6">
+                        <CardContent className="space-y-2 p-3">
                             {quickActions.map((action) => {
                                 const Icon = action.icon;
 
@@ -290,15 +285,125 @@ export default function Dashboard({ stats, recentPosts, draftPostsList, postsTre
                                     <Link
                                         key={action.label}
                                         href={action.href}
-                                        className="flex flex-col items-center gap-2 rounded-lg border bg-card px-4 py-5 text-center transition-colors hover:bg-muted/50"
+                                        className="group flex items-center gap-3 rounded-lg border border-transparent px-3 py-2.5 transition-colors hover:border-border hover:bg-muted/60"
                                     >
-                                        <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                                            <Icon className="h-5 w-5" />
+                                        <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                                            <Icon className="h-[18px] w-[18px]" />
                                         </span>
-                                        <span className="text-sm font-medium text-foreground">{action.label}</span>
+                                        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                                            {action.label}
+                                        </span>
+                                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
                                     </Link>
                                 );
                             })}
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <div className="grid gap-6 lg:grid-cols-2">
+                    {/* Recent Published Posts */}
+                    <Card className="flex flex-col">
+                        <CardHeader className="flex-row items-center justify-between gap-4 space-y-0 border-b p-5">
+                            <div className="flex items-center gap-2.5">
+                                <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-100 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
+                                    <CheckCircle2 className="h-4 w-4" />
+                                </span>
+                                <CardTitle className="text-base font-semibold">Recent Published Posts</CardTitle>
+                            </div>
+                            <CountBadge value={recentPosts.length} />
+                        </CardHeader>
+                        <CardContent className="flex-1 divide-y p-0">
+                            {recentPosts.length > 0 ? recentPosts.map((post) => (
+                                <Link
+                                    key={post.slug}
+                                    href={post.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="group flex items-start gap-3 px-4 py-3.5 transition-colors hover:bg-muted/50 sm:px-5"
+                                >
+                                    {post.coverImageUrl ? (
+                                        <img
+                                            src={getImageUrl(post.coverImageUrl)}
+                                            alt=""
+                                            loading="lazy"
+                                            className="h-12 w-16 shrink-0 rounded-md border object-cover"
+                                        />
+                                    ) : (
+                                        <span className="inline-flex h-12 w-16 shrink-0 items-center justify-center rounded-md border bg-muted text-muted-foreground">
+                                            <FileText className="h-4 w-4" />
+                                        </span>
+                                    )}
+
+                                    <div className="min-w-0 flex-1">
+                                        <p className="truncate text-sm font-medium text-foreground group-hover:text-primary">
+                                            {post.title}
+                                        </p>
+                                        <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{post.brief}</p>
+                                        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                            <span className="inline-flex items-center gap-1">
+                                                <CalendarDays className="h-3.5 w-3.5" />
+                                                {post.publishedAtHuman}
+                                            </span>
+                                            <span className="inline-flex items-center gap-1">
+                                                <Clock className="h-3.5 w-3.5" />
+                                                {post.readTimeLabel}
+                                            </span>
+                                        </div>
+                                    </div>
+
+                                    <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                                </Link>
+                            )) : (
+                                <EmptyState icon={Inbox} message="No published posts yet." />
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    {/* Draft Posts */}
+                    <Card className="flex flex-col">
+                        <CardHeader className="flex-row items-center justify-between gap-4 space-y-0 border-b p-5">
+                            <div className="flex items-center gap-2.5">
+                                <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400">
+                                    <PenLine className="h-4 w-4" />
+                                </span>
+                                <CardTitle className="text-base font-semibold">Draft Posts</CardTitle>
+                            </div>
+                            <CountBadge value={draftPostsList.length} />
+                        </CardHeader>
+                        <CardContent className="flex-1 divide-y p-0">
+                            {draftPostsList.length > 0 ? draftPostsList.map((post) => (
+                                <div
+                                    key={post.slug}
+                                    className="flex items-start gap-3 px-4 py-3.5 sm:px-5"
+                                >
+                                    <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-amber-500" aria-hidden="true" />
+
+                                    <div className="min-w-0 flex-1">
+                                        <p className="text-sm font-medium text-foreground">{post.title}</p>
+                                        <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{post.brief}</p>
+                                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                                            <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-950 dark:text-amber-400">
+                                                <Clock className="h-3 w-3" />
+                                                {post.readTimeLabel}
+                                            </span>
+                                            {post.draftPreviewUrl && (
+                                                <a
+                                                    href={post.draftPreviewUrl}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+                                                >
+                                                    <ExternalLink className="h-3 w-3" />
+                                                    Preview
+                                                </a>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            )) : (
+                                <EmptyState icon={PenLine} message="No draft posts." />
+                            )}
                         </CardContent>
                     </Card>
                 </div>

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -315,7 +315,7 @@ export default function Dashboard({ stats, panelStatus, panelStatusDetail, recen
                         </CardHeader>
                         <CardContent className="flex-1 divide-y p-0">
                             {recentPosts.length > 0 ? recentPosts.map((post) => (
-                                <Link
+                                <a
                                     key={post.slug}
                                     href={post.url}
                                     target="_blank"
@@ -353,7 +353,7 @@ export default function Dashboard({ stats, panelStatus, panelStatusDetail, recen
                                     </div>
 
                                     <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
-                                </Link>
+                                </a>
                             )) : (
                                 <EmptyState icon={Inbox} message="No published posts yet." />
                             )}

--- a/routes/web.php
+++ b/routes/web.php
@@ -95,6 +95,9 @@ Route::get('/admin', fn () => redirect()->route('dashboard'))
     ->middleware(['auth', 'verified', 'role:admin'])
     ->name('admin');
 
+// Legacy bookmark support: the dashboard used to live at /dashboard.
+Route::redirect('/dashboard', '/admin/dashboard');
+
 // Admin CRUD for link-in-bio entries
 Route::middleware(['auth', 'verified', 'role:admin'])
     ->prefix('admin/bio')

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,8 +42,8 @@ Route::get('/', function () {
     return Inertia::render('Homepage');
 })->name('home');
 
-// The same admin dashboard view is served at both /dashboard and /admin, so
-// the payload-building logic lives in one closure shared by both routes.
+// The admin dashboard view is served at /admin/dashboard; /admin itself just
+// redirects there. The payload-building logic lives in this closure.
 $renderDashboard = function () {
     $blog = new BlogRepository();
     $posts = $blog->posts();
@@ -87,11 +87,11 @@ $renderDashboard = function () {
     ]);
 };
 
-Route::get('/dashboard', $renderDashboard)
+Route::get('/admin/dashboard', $renderDashboard)
     ->middleware(['auth', 'verified', 'role:admin'])
     ->name('dashboard');
 
-Route::get('/admin', $renderDashboard)
+Route::get('/admin', fn () => redirect()->route('dashboard'))
     ->middleware(['auth', 'verified', 'role:admin'])
     ->name('admin');
 

--- a/tests/Feature/AdminPanelTest.php
+++ b/tests/Feature/AdminPanelTest.php
@@ -24,7 +24,7 @@ class AdminPanelTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->get(route('admin'))
+            ->get(route('dashboard'))
             ->assertOk()
             ->assertInertia(function (Assert $page): void {
                 $page->component('Dashboard')
@@ -33,5 +33,17 @@ class AdminPanelTest extends TestCase
                     ->has('recentPosts')
                     ->has('draftPostsList');
             });
+    }
+
+    public function test_admin_panel_redirects_verified_users_to_dashboard(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => 'admin',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('admin'))
+            ->assertRedirect(route('dashboard'));
     }
 }


### PR DESCRIPTION
## Summary
- Visual revamp of the admin dashboard (stat cards, chart styling, post lists, quick actions) in `resources/js/Pages/Dashboard.tsx`
- Dashboard route moved from `/dashboard` to `/admin/dashboard` (route name `dashboard` unchanged); bare `/admin` now redirects there; old `/dashboard` URL now redirects to `/admin/dashboard` too, so existing bookmarks keep working
- Fixed hardcoded `/dashboard` links in `Menubar.tsx` and the `isAdminPath` check in `SubscribeProvider.tsx` to match the new prefix
- New-tab rule applied to outbound content links: "Recent Published Posts" links and the sidebar logo link now genuinely open in a new tab on a plain click, using native `<a target="_blank" rel="noopener noreferrer">` instead of Inertia's `<Link>` (Inertia's client-side navigation intercepts left-clicks regardless of the `target` prop, so the initial `<Link target="_blank">` attempt was a no-op for normal clicks)
- Removed the dead "Posts" sidebar nav item, which duplicated "Dashboard" and could never be marked active now that `/admin` always redirects

## Review fixes (round 2)
- `AdminPanelTest`: dashboard-render assertions now hit `route('dashboard')` instead of `route('admin')` (which now 302s), plus a new test asserting `/admin` redirects authenticated admins to `/admin/dashboard`
- Recent-post links and sidebar logo swapped from Inertia `<Link>` to plain `<a target="_blank" rel="noopener noreferrer">`
- Dead "Posts" nav item removed from the sidebar
- Added `Route::redirect('/dashboard', '/admin/dashboard')` for legacy bookmarks

## Test plan
- [x] `php artisan test` — full suite green (174 tests)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Bare `/admin` redirects to `/admin/dashboard`
- [x] Old `/dashboard` URL redirects to `/admin/dashboard`
- [x] Dashboard renders with the new visual design (stat cards, chart, post lists, quick actions), no console errors
- [x] "Recent Published Posts" links open in a new tab on a plain click (`target="_blank"`, `rel="noopener noreferrer"`, confirmed via DOM inspection, not just ctrl-click)
- [x] Sidebar logo link opens in a new tab on a plain click
- [x] Sidebar no longer shows a "Posts" item
- [x] Internal sidebar nav links (Dashboard, Bio Links, Media, Short Links, API Keys, Profile) stay same-tab and highlight correctly for the active route
- [x] No newsletter popup on `/admin/dashboard`, `/profile`, or `/admin/*`
- [x] Verified against the sqlite fixture DB, then reverted `.env` back to pgsql/portfolio

Generated with [Claude Code](https://claude.ai/code)