### PR TITLE
fix: center bio page language switcher and clarify its label

### DIFF
--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -280,7 +280,7 @@ export default function Bio({
   const monoFont = locale === 'bn' ? 'font-bengali' : 'font-mono'
   // Mutual switcher between /bio and /hrr. The label is always set in its
   // own script's font, regardless of which page it's rendered on, so
-  // "বাংলা" reads correctly even in the Latin-only English page.
+  // "বাংলা প্রোফাইল" reads correctly even in the Latin-only English page.
   const otherLocale: BioLocale = locale === 'bn' ? 'en' : 'bn'
   const otherLocaleHref = otherLocale === 'bn' ? '/hrr' : '/bio'
   const otherLocaleLabel = otherLocale === 'bn' ? 'বাংলা প্রোফাইল' : 'English profile'

--- a/resources/js/Pages/Bio.tsx
+++ b/resources/js/Pages/Bio.tsx
@@ -283,7 +283,7 @@ export default function Bio({
   // "বাংলা" reads correctly even in the Latin-only English page.
   const otherLocale: BioLocale = locale === 'bn' ? 'en' : 'bn'
   const otherLocaleHref = otherLocale === 'bn' ? '/hrr' : '/bio'
-  const otherLocaleLabel = otherLocale === 'bn' ? 'বাংলা' : 'English'
+  const otherLocaleLabel = otherLocale === 'bn' ? 'বাংলা প্রোফাইল' : 'English profile'
   const otherLocaleFont = otherLocale === 'bn' ? 'font-bengali' : 'font-mono'
   // Real page URL. Feeds SEO tags (og:url, canonical). Must stay the actual
   // page, never the shortener redirect.
@@ -469,41 +469,41 @@ export default function Bio({
           transition={{ duration: 0.6, ease: 'easeOut' }}
           className="relative mx-auto flex min-h-[calc(100svh-6rem)] w-full max-w-xl flex-col items-center pt-12"
         >
-          {/* Header: Home + language switch sit top-left; Subscribe + whole-page share stay paired top-right */}
-          <div className="absolute inset-x-0 top-0 flex items-center justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-3">
+          {/* Header: Home + Subscribe/Share sit in equal-width flex-1 zones so the language switch stays truly centered between them at every width */}
+          <div className="absolute inset-x-0 top-0 flex items-center gap-3">
+            <div className="flex min-w-0 flex-1 items-center">
               <Link
                 href="/"
-                className={`group inline-flex shrink-0 items-center gap-1.5 rounded-sm ${monoFont} text-xs font-medium uppercase tracking-wider text-[#5b4a3a] transition-colors hover:text-[#b8541f] focus-visible:text-[#b8541f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]`}
+                className={`group inline-flex min-w-0 items-center gap-1.5 rounded-sm ${monoFont} text-xs font-medium uppercase tracking-wider text-[#5b4a3a] transition-colors hover:text-[#b8541f] focus-visible:text-[#b8541f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]`}
               >
-                <ArrowLeft className="h-3.5 w-3.5 transition-transform group-hover:-translate-x-0.5" />
-                <span className="underline decoration-[#5b4a3a]/40 underline-offset-4 transition-colors group-hover:decoration-[#b8541f]">
+                <ArrowLeft className="h-3.5 w-3.5 shrink-0 transition-transform group-hover:-translate-x-0.5" />
+                <span className="truncate underline decoration-[#5b4a3a]/40 underline-offset-4 transition-colors group-hover:decoration-[#b8541f]">
                   {t.home}
-                </span>
-              </Link>
-
-              <Link
-                href={otherLocaleHref}
-                className={`group inline-flex shrink-0 items-center gap-1.5 rounded-sm ${otherLocaleFont} text-xs font-medium uppercase tracking-wider text-[#5b4a3a] transition-colors hover:text-[#b8541f] focus-visible:text-[#b8541f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]`}
-              >
-                <Languages className="h-3.5 w-3.5" />
-                <span className="underline decoration-[#5b4a3a]/40 underline-offset-4 transition-colors group-hover:decoration-[#b8541f]">
-                  {otherLocaleLabel}
                 </span>
               </Link>
             </div>
 
-            <div className="flex items-center gap-2">
+            <Link
+              href={otherLocaleHref}
+              className={`group inline-flex shrink-0 items-center gap-1.5 rounded-sm ${otherLocaleFont} text-xs font-medium uppercase tracking-wider text-[#5b4a3a] transition-colors hover:text-[#b8541f] focus-visible:text-[#b8541f] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]`}
+            >
+              <Languages className="h-3.5 w-3.5" />
+              <span className="underline decoration-[#5b4a3a]/40 underline-offset-4 transition-colors group-hover:decoration-[#b8541f]">
+                {otherLocaleLabel}
+              </span>
+            </Link>
+
+            <div className="flex min-w-0 flex-1 items-center justify-end gap-2">
               <button
                 type="button"
                 onClick={() => openPopup('bio-header', 'warm')}
-                className={`flex h-10 items-center gap-1.5 rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 px-4 ${monoFont} text-xs font-medium uppercase tracking-wider text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]`}
+                className={`flex h-10 min-w-0 items-center gap-1.5 rounded-full border border-[#e4d7c4] bg-[#fffaf6]/90 px-4 ${monoFont} text-xs font-medium uppercase tracking-wider text-[#5b4a3a] shadow-sm backdrop-blur transition hover:border-[#c98a4b] hover:text-[#2b2320] focus-visible:border-[#c98a4b] focus-visible:text-[#2b2320] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b8541f]`}
               >
-                <Mail className="h-4 w-4" />
-                {t.subscribe}
+                <Mail className="h-4 w-4 shrink-0" />
+                <span className="truncate">{t.subscribe}</span>
               </button>
 
-              <div className="relative" ref={openMenu === 'page' ? menuRef : null}>
+              <div className="relative shrink-0" ref={openMenu === 'page' ? menuRef : null}>
                 <button
                   type="button"
                   onClick={() => setOpenMenu(openMenu === 'page' ? null : 'page')}


### PR DESCRIPTION
## Summary
- Moves the bio page's language switcher (`/bio` ↔ `/hrr`) out of the left-grouped Home link into its own truly centered element in the header, independent of Home/Subscribe/Share widths.
- Relabels it "English profile" / "বাংলা প্রোফাইল" instead of the bare "English" / "বাংলা", keeping the existing convention that the label always renders in the *target* locale's own script.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified in a real browser against a local sqlite fixture DB (Playwright MCP):
  - [x] `/bio`: switcher reads "বাংলা প্রোফাইল", href `/hrr`, horizontally centered (0px offset from viewport center)
  - [x] `/hrr`: switcher reads "English profile", href `/bio`, horizontally centered (0px offset)
  - [x] Clicking the switcher navigates correctly between `/bio` and `/hrr`
  - [x] Home link and Subscribe/Share controls unaffected
  - [x] No visual overlap at 375px mobile viewport

Generated with [Claude Code](https://claude.ai/code)