### PR TITLE
Add devurl.sh shortcut

### DIFF
--- a/devurl.sh
+++ b/devurl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# devurl.sh — shortcut for scripts/tailscale-dev/url.sh
+# Usage: ./devurl.sh [path] | ./devurl.sh --all
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+exec bash "$SCRIPT_DIR/scripts/tailscale-dev/url.sh" "$@"


### PR DESCRIPTION
## Summary
- Adds `devurl.sh` at the repo root as a thin wrapper over `scripts/tailscale-dev/url.sh`, so the Tailscale dev-URL lookup is reachable as `./devurl.sh` / `./devurl.sh --all` without the nested path.

## Test plan
- [x] `./devurl.sh --all` — lists all three currently-provisioned checkouts (main, this worktree, railway-migration) correctly

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017MP2KAjp5c4BAvyW62SYiQ