### PR TITLE
fix: register tailscale-dev herdr plugin via herdr plugin link

### DIFF
--- a/scripts/tailscale-dev/herdr-plugin/reconcile.sh
+++ b/scripts/tailscale-dev/herdr-plugin/reconcile.sh
@@ -16,8 +16,7 @@ REPO_SCRIPTS_DIR="$(cd -- "$SCRIPT_DIR/.." &>/dev/null && pwd)"
 # shellcheck source=../lib.sh
 source "$REPO_SCRIPTS_DIR/lib.sh"
 
-worktree_list=$(git -C "$MAIN_REPO" worktree list --porcelain)
-if [[ $? -ne 0 ]]; then
+if ! worktree_list=$(git -C "$MAIN_REPO" worktree list --porcelain); then
   echo "tailscale-dev: git worktree list --porcelain failed -- aborting reconcile (refusing to treat this as \"nothing is checked out\")" >&2
   exit 1
 fi

--- a/scripts/tailscale-dev/install-herdr-plugin.sh
+++ b/scripts/tailscale-dev/install-herdr-plugin.sh
@@ -2,26 +2,41 @@
 # scripts/tailscale-dev/install-herdr-plugin.sh
 # One-time, explicit, human-run step. Nothing else in this repo writes to
 # ~/.herdr/ on its own.
+#
+# Registers the plugin via `herdr plugin link`, which creates the
+# ~/.herdr/plugins/tailscale-portfolio symlink AND records it in herdr's own
+# plugins.json. A hand-rolled symlink at that path is not enough -- herdr
+# only loads plugins it has explicitly linked/installed, so a symlink herdr
+# doesn't know about never fires worktree.created/worktree.removed.
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-SRC="$SCRIPT_DIR/herdr-plugin"
-DEST="$HOME/.herdr/plugins/tailscale-portfolio"
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
 
+SRC="$MAIN_REPO/scripts/tailscale-dev/herdr-plugin"
+DEST="$HOME/.herdr/plugins/tailscale-portfolio"
+PLUGIN_ID="tailscale-portfolio"
+
+[[ -d "$SRC" ]] || { echo "tailscale-dev: plugin source not found at $SRC (is MAIN_REPO set correctly?)" >&2; exit 1; }
+command -v herdr >/dev/null 2>&1 || { echo "tailscale-dev: 'herdr' not found on PATH" >&2; exit 1; }
+
+if herdr plugin list 2>/dev/null | grep -qE "^- ${PLUGIN_ID} "; then
+  echo "tailscale-dev: $PLUGIN_ID is already registered with herdr"
+  exit 0
+fi
+
+# A prior version of this script hand-symlinked $DEST without ever calling
+# `herdr plugin link`, so herdr never loaded it -- clear that out first so
+# `herdr plugin link` doesn't trip over a path it doesn't own.
 if [[ -L "$DEST" ]]; then
   current=$(readlink "$DEST")
-  if [[ "$current" == "$SRC" ]]; then
-    echo "tailscale-dev: already installed at $DEST -> $SRC"
-    exit 0
-  fi
-  if [[ ! -e "$DEST" ]]; then
-    # Dangling symlink (its target no longer exists on disk, e.g. a worktree
-    # removed after merge) -- safely replaceable, not "points somewhere else".
-    echo "tailscale-dev: $DEST is a dangling symlink (-> $current, target missing) -- replacing it"
+  if [[ "$current" == "$SRC" || ! -e "$DEST" ]]; then
+    echo "tailscale-dev: removing stale unregistered symlink at $DEST"
     rm -f "$DEST"
   else
-    echo "tailscale-dev: $DEST is a symlink to something else ($current) -- refusing to overwrite" >&2
+    echo "tailscale-dev: $DEST is a symlink to something else ($current) -- refusing to touch it" >&2
     exit 1
   fi
 elif [[ -e "$DEST" ]]; then
@@ -29,7 +44,11 @@ elif [[ -e "$DEST" ]]; then
   exit 1
 fi
 
-mkdir -p "$(dirname "$DEST")"
-ln -s "$SRC" "$DEST" || { echo "tailscale-dev: failed to symlink $DEST -> $SRC" >&2; exit 1; }
-echo "tailscale-dev: installed $DEST -> $SRC"
-echo "tailscale-dev: run 'herdr server reload-config' (or restart herdr) to pick it up"
+herdr plugin link "$SRC" || { echo "tailscale-dev: 'herdr plugin link' failed" >&2; exit 1; }
+
+if herdr plugin list 2>/dev/null | grep -qE "^- ${PLUGIN_ID} "; then
+  echo "tailscale-dev: $PLUGIN_ID registered and enabled"
+else
+  echo "tailscale-dev: 'herdr plugin link' returned success but $PLUGIN_ID is still not in 'herdr plugin list' -- registration did not take" >&2
+  exit 1
+fi

--- a/scripts/tailscale-dev/provision.sh
+++ b/scripts/tailscale-dev/provision.sh
@@ -92,7 +92,7 @@ mkdir -p "$TARGET/storage/logs"
     "php artisan serve --port=$BACKEND_PORT" \
     "php artisan queue:listen --tries=1" \
     "php artisan pail --timeout=0" \
-    "npm run dev -- --port=$VITE_PORT --host=127.0.0.1"
+    "npm run dev -- --port=$VITE_PORT --host=127.0.0.1 --strictPort"
 ) >>"$TARGET/storage/logs/tailscale-dev.log" 2>&1 &
 GROUP_PID=$!
 disown


### PR DESCRIPTION
## Summary
- `install-herdr-plugin.sh` only hand-symlinked `~/.herdr/plugins/tailscale-portfolio` and never registered it with herdr, so `worktree.created`/`worktree.removed` never fired and worktrees were never auto-provisioned
- Switch to `herdr plugin link`, which symlinks **and** registers the plugin (verified live: `herdr plugin list` now shows `tailscale-portfolio` enabled, and a manual `reconcile.sh` run correctly provisioned this worktree and tore down a stale leaked one)
- Add `--strictPort` to the Vite dev command so provisioning fails loudly instead of silently mounting `tailscale serve` at a port Vite didn't actually bind (main's Vite had drifted to 5174 while its mount pointed at 5173)
- Fix a fragile `$?`-after-assignment check in `reconcile.sh`

## Test plan
- [x] `bash scripts/tailscale-dev/install-herdr-plugin.sh` → plugin registers, `herdr plugin list` shows it enabled
- [x] `bash scripts/tailscale-dev/herdr-plugin/reconcile.sh` → provisioned this worktree (symlinks + tailscale mount + dev server), tore down a stale leaked worktree's mounts/registry entry
- [x] Re-provisioned main; Vite bind and tailscale mount now agree on port 5173
- [ ] `bash scripts/tailscale-dev/test-lib.sh` still passes

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01EDQApEsebCtr44dAt1UDHX