### PR TITLE
fix: prepend Homebrew/local bin dirs to PATH in tailscale-dev lib.sh

### DIFF
--- a/scripts/tailscale-dev/lib.sh
+++ b/scripts/tailscale-dev/lib.sh
@@ -5,6 +5,17 @@
 
 set -uo pipefail
 
+# herdr invokes plugin commands (worktree.created/worktree.removed/startup)
+# with a PATH that doesn't reliably include Homebrew or /usr/local/bin --
+# confirmed live: an interactive shell finds tailscale at /usr/local/bin, but
+# the same lookup failed when this file was sourced from a herdr-invoked
+# reconcile.sh, while jq (/opt/homebrew/bin) resolved fine in that same
+# invocation. Prepend both so provisioning doesn't depend on the caller's PATH.
+for dir in /opt/homebrew/bin /usr/local/bin; do
+  [[ ":$PATH:" == *":$dir:"* ]] || PATH="$dir:$PATH"
+done
+export PATH
+
 : "${MAIN_REPO:=/Users/rayhan/Code/haruns-portfolio}"
 : "${TAILSCALE_DEV_REGISTRY:=$HOME/.config/herdr/plugins/config/tailscale-portfolio/registry.json}"
 


### PR DESCRIPTION
## Summary
Follow-up to #144, found by live-testing it. Creating a real herdr worktree fired `worktree.created` → `reconcile.sh` correctly (confirmed in `herdr plugin log list`), but it failed with `tailscale: not found on PATH`. herdr's plugin execution PATH includes `/opt/homebrew/bin` but not `/usr/local/bin`, where `tailscale` lives on this machine.

## Test plan
- [x] Simulated herdr's stripped PATH (`env -i HOME=$HOME PATH=/usr/bin:/bin:/usr/sbin:/sbin`) and confirmed `lib.sh` now resolves `tailscale`/`jq`/`git`
- [ ] Real herdr worktree create/remove cycle succeeds end-to-end (pending merge + pull into main checkout)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01EDQApEsebCtr44dAt1UDHX