### PR TITLE
fix: real vendor/ per worktree, per-checkout scoped repository cache keys

### DIFF
--- a/app/Console/Commands/PublishScheduledPosts.php
+++ b/app/Console/Commands/PublishScheduledPosts.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Support\BlogRepository;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Carbon;
@@ -67,7 +68,7 @@ class PublishScheduledPosts extends Command
 
         if ($published) {
             try {
-                Cache::forget('blog.repository.payload');
+                Cache::forget(BlogRepository::cacheKey());
                 $this->info(sprintf('Published %d post(s). Blog cache cleared.', count($published)));
             } catch (\Throwable $e) {
                 $this->warn(sprintf('Published %d post(s). Could not clear cache: %s', count($published), $e->getMessage()));

--- a/app/Support/BlogRepository.php
+++ b/app/Support/BlogRepository.php
@@ -19,6 +19,19 @@ class BlogRepository
     private const CACHE_TTL_MINUTES = 15;
 
     /**
+     * The cache store (`database`, a shared Postgres DB per §2.1 of the
+     * tailscale-dev design doc) is shared by every worktree checkout running
+     * as the same OS user. Scoping the key by base_path() keeps each
+     * checkout's dev server reading/writing its own cached post list instead
+     * of clobbering another worktree's, which otherwise produces phantom
+     * 404s for posts that only exist in one worktree's resources/blog/posts/.
+     */
+    public static function cacheKey(): string
+    {
+        return self::CACHE_KEY.'.'.md5(base_path());
+    }
+
+    /**
      * @var array<string, mixed>|null
      */
     private ?array $data = null;
@@ -193,7 +206,7 @@ class BlogRepository
             return $this->data;
         }
 
-        $this->data = Cache::remember(self::CACHE_KEY, now()->addMinutes(self::CACHE_TTL_MINUTES), function (): array {
+        $this->data = Cache::remember(self::cacheKey(), now()->addMinutes(self::CACHE_TTL_MINUTES), function (): array {
             $publication = $this->loadPublication();
             $posts = collect(glob(resource_path(self::CONTENT_DIR.'/*.md')) ?: [])
                 ->map(fn (string $path) => $this->parsePostFile($path, $publication))

--- a/app/Support/CaseStudyRepository.php
+++ b/app/Support/CaseStudyRepository.php
@@ -16,6 +16,17 @@ class CaseStudyRepository
     private const CACHE_TTL_MINUTES = 15;
 
     /**
+     * See BlogRepository::cacheKey() -- same rationale: the `database` cache
+     * store is a shared Postgres DB across every worktree checkout, so the
+     * key is scoped by base_path() to keep each checkout's cached case study
+     * list independent of the others.
+     */
+    public static function cacheKey(): string
+    {
+        return self::CACHE_KEY.'.'.md5(base_path());
+    }
+
+    /**
      * @var array<int, array<string, mixed>>|null
      */
     private ?array $studies = null;
@@ -230,7 +241,7 @@ class CaseStudyRepository
             return $this->studies;
         }
 
-        $this->studies = Cache::remember(self::CACHE_KEY, now()->addMinutes(self::CACHE_TTL_MINUTES), function (): array {
+        $this->studies = Cache::remember(self::cacheKey(), now()->addMinutes(self::CACHE_TTL_MINUTES), function (): array {
             $paths = glob(resource_path(self::CONTENT_DIR.'/[!_.]*.md')) ?: [];
 
             if ($paths === []) {

--- a/scripts/tailscale-dev/provision.sh
+++ b/scripts/tailscale-dev/provision.sh
@@ -51,7 +51,7 @@ if [[ "$IS_MAIN" == false ]]; then
     echo "tailscale-dev: refusing to clobber existing $vendor_dst (not a directory)" >&2
     exit 1
   fi
-  if [[ ! -d "$vendor_dst" ]]; then
+  if [[ ! -f "$vendor_dst/autoload.php" ]]; then
     echo "tailscale-dev: running composer install in $TARGET (independent vendor/, using its own composer.lock)..." >&2
     if ! (cd "$TARGET" && composer install --no-interaction --no-ansi --prefer-dist --no-progress); then
       echo "tailscale-dev: composer install failed in $TARGET -- see output above" >&2
@@ -61,8 +61,8 @@ if [[ "$IS_MAIN" == false ]]; then
 fi
 
 # Checked after the symlink step above: a non-main worktree has no .env of
-# its own until node_modules/vendor/.env are symlinked in; checking before
-# that would always fail. Main's own .env is already present either way.
+# its own until node_modules/.env are symlinked in; checking before that
+# would always fail. Main's own .env is already present either way.
 guard::require_local_env "$TARGET"
 
 SLUG=$(slug::for_path "$TARGET")

--- a/scripts/tailscale-dev/provision.sh
+++ b/scripts/tailscale-dev/provision.sh
@@ -17,7 +17,7 @@ IS_MAIN=false
 [[ "$TARGET" == "$MAIN_REPO" ]] && IS_MAIN=true
 
 if [[ "$IS_MAIN" == false ]]; then
-  for item in node_modules vendor .env .claude/settings.local.json; do
+  for item in node_modules .env .claude/settings.local.json; do
     src="$MAIN_REPO/$item"
     dst="$TARGET/$item"
     if [[ -L "$dst" ]]; then
@@ -29,6 +29,35 @@ if [[ "$IS_MAIN" == false ]]; then
       ln -s "$src" "$dst" || { echo "tailscale-dev: failed to symlink $dst -> $src" >&2; exit 1; }
     fi
   done
+
+  # vendor/ is deliberately NOT symlinked (unlike node_modules/.env above).
+  # PHP's __DIR__ resolves through symlinks, so a symlinked vendor/ makes
+  # Composer's generated vendor/autoload_psr4.php compute its base directory
+  # from the *resolved* main-checkout path, mapping the App\ namespace to
+  # the main checkout's app/ instead of this worktree's own -- any backend
+  # PHP change made here is silently invisible to this worktree's own dev
+  # server. Instead, give this worktree a real, independent vendor/ via
+  # `composer install` against its own composer.lock (never `composer
+  # update` -- dependencies must stay identical to whatever's on this
+  # branch). Composer's global package cache means this is normally fast
+  # even though it's a full install.
+  vendor_dst="$TARGET/vendor"
+  if [[ -L "$vendor_dst" ]]; then
+    # Migrate away from a stale symlink left by an older version of this
+    # script (pre-dating the fix above).
+    rm "$vendor_dst" || { echo "tailscale-dev: failed to remove stale vendor symlink at $vendor_dst" >&2; exit 1; }
+  fi
+  if [[ -e "$vendor_dst" && ! -d "$vendor_dst" ]]; then
+    echo "tailscale-dev: refusing to clobber existing $vendor_dst (not a directory)" >&2
+    exit 1
+  fi
+  if [[ ! -d "$vendor_dst" ]]; then
+    echo "tailscale-dev: running composer install in $TARGET (independent vendor/, using its own composer.lock)..." >&2
+    if ! (cd "$TARGET" && composer install --no-interaction --no-ansi --prefer-dist --no-progress); then
+      echo "tailscale-dev: composer install failed in $TARGET -- see output above" >&2
+      exit 1
+    fi
+  fi
 fi
 
 # Checked after the symlink step above: a non-main worktree has no .env of


### PR DESCRIPTION
## Summary
- `scripts/tailscale-dev/provision.sh` no longer symlinks `vendor/` into new worktrees. PHP's `__DIR__` resolves through symlinks, so Composer's generated `vendor/autoload_psr4.php` computed its base directory from the *resolved* main-checkout path, mapping `App\` to main's `app/` instead of the worktree's own — any backend PHP change made in a provisioned worktree was silently invisible to that worktree's own dev server. Provisioning now runs `composer install` (never `composer update`) against the worktree's own `composer.lock`, giving it a real, independent `vendor/`. Failure is now surfaced clearly instead of falling through to a broken worktree. A stale symlink from an older run of the script is detected and replaced.
- `BlogRepository` and `CaseStudyRepository` cached their parsed content list under a literal, non-worktree-scoped key in the `database` cache store — a shared Postgres DB across every worktree running as the same OS user. Two worktrees hitting `/blog` or `/case-studies` around the same time could clobber each other's cached list, producing phantom 404s for posts/studies that only exist in one worktree's content directory. Both repositories now expose a `cacheKey()` static method that scopes the key by `md5(base_path())`, computed once per class so it can't drift. `PublishScheduledPosts` (which called `Cache::forget('blog.repository.payload')` directly) now calls `BlogRepository::cacheKey()` instead.

## Test plan
- Provisioned a real throwaway worktree with the patched `provision.sh` end-to-end (real `composer install`, real dev server launch, real `tailscale serve` mounts) — completed in ~10s thanks to Composer's package cache (no network re-download). `vendor/` came out as a real directory, not a symlink.
- Dropped a throwaway autoload-probe class into that worktree's own `app/Support/`, called it via `php artisan tinker`, and confirmed via `ReflectionClass::getFileName()` that `App\` resolved to the worktree's own `app/Support/AutoloadProbe.php`, not the main checkout's. Removed the probe class and fully tore the worktree down (`teardown.sh` + `git worktree remove`) afterward — registry and `ps` confirmed clean.
- Confirmed `BlogRepository::cacheKey()`/`CaseStudyRepository::cacheKey()` differ for different `base_path()` values (verified via `php artisan tinker` against this worktree's own path vs. the main checkout's path), and confirmed the two keys land as distinct rows in the shared Postgres `cache` table.
- Cleared cache, hit `/blog` and `/blog/{an-existing-published-slug}` against the real running app (Inertia JSON path, so no frontend build required) — both returned 200 with correct content.
- `vendor/bin/phpunit` (full suite): 173 tests, 540 assertions, all passing.
- `vendor/bin/pint --test` on the touched PHP files reports the same pre-existing fixer violations (`unary_operator_spaces`, `not_operator_with_successor_space`, etc.) as the unmodified files on `main` — confirmed byte-identical baseline, so nothing new was introduced by this change; left untouched to keep the diff scoped to the two fixes.

Generated with [Claude Code](https://claude.ai/code)